### PR TITLE
Store state in the router

### DIFF
--- a/components/Search.tsx
+++ b/components/Search.tsx
@@ -103,9 +103,11 @@ export const CONTENT_GQL = gql`
 export const Search: React.FunctionComponent = () => {
   const router = useRouter()
   const [searchQuery, setSearchQuery] = useQueryState("query", { history: 'push' })
+  /* eslint-disable no-unused-vars */
   const [published, setPublished] = useQueryState('published', { history: 'push' })
   const [resourceType, setResourceType] = useQueryState('resource-type', { history: 'push' })
   const [registrationAgency, setRegistrationAgency] = useQueryState('registration-agency', { history: 'push' })
+  /* eslint-enable no-unused-vars */
   const [searchResults, setSearchResults] = React.useState([])
   const { loading, error, data, refetch, fetchMore } = useQuery<ContentQueryData, ContentQueryVar>(
     CONTENT_GQL,

--- a/components/Search.tsx
+++ b/components/Search.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { useRouter } from 'next/router'
 import { useQuery } from "@apollo/react-hooks"
+import { useQueryState } from 'next-usequerystate'
 import { gql } from "apollo-boost"
 import { Alert, Button } from 'react-bootstrap'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
@@ -9,10 +10,6 @@ import { faSquare, faCheckSquare } from '@fortawesome/free-regular-svg-icons'
 import Link from 'next/link'
 import ContentItem from "./ContentItem"
 import Error from "./Error"
-
-type Props = {
-
-}
 
 interface ContentNode {
   node: ContentItem
@@ -46,11 +43,12 @@ interface ContentQueryVar {
   cursor: string
   published: string
   resourceTypeId: string
+  registrationAgency: string
 }
 
 export const CONTENT_GQL = gql`
-  query getContentQuery($query: String!, $cursor: String, $published: String, $resourceTypeId: String) {
-    works(first: 25, query: $query, after: $cursor, published: $published, resourceTypeId: $resourceTypeId) {
+  query getContentQuery($query: String, $cursor: String, $published: String, $resourceTypeId: String, $registrationAgency: String) {
+    works(first: 25, query: $query, after: $cursor, published: $published, resourceTypeId: $resourceTypeId, registrationAgency: $registrationAgency) {
       totalCount
       pageInfo {
         endCursor
@@ -102,28 +100,26 @@ export const CONTENT_GQL = gql`
   }
 `
 
-export const Search: React.FunctionComponent<Props> = () => {
+export const Search: React.FunctionComponent = () => {
   const router = useRouter()
-  // set initial searchQuery to query parameter in route
-  const [searchQuery, setSearchQuery] = React.useState(router.query.query as string || "")
+  const [searchQuery, setSearchQuery] = useQueryState("query", { history: 'push' })
+  const [published, setPublished] = useQueryState('published', { history: 'push' })
+  const [resourceType, setResourceType] = useQueryState('resource-type', { history: 'push' })
+  const [registrationAgency, setRegistrationAgency] = useQueryState('registration-agency', { history: 'push' })
   const [searchResults, setSearchResults] = React.useState([])
   const { loading, error, data, refetch, fetchMore } = useQuery<ContentQueryData, ContentQueryVar>(
     CONTENT_GQL,
     {
       errorPolicy: 'all',
-      variables: { query: "", cursor: "", published: router.query.published as string, resourceTypeId: router.query['resource-type'] as string }
+      variables: { query: searchQuery, cursor: '', published: published as string, resourceTypeId: resourceType as string, registrationAgency: registrationAgency as string }
     }
   )
 
   const onSearchChange = (e: React.FormEvent<HTMLInputElement>): void => {
-    // sync searchQuery and query parameter in route
-    router.push('/?query=' + e.currentTarget.value)
     setSearchQuery(e.currentTarget.value)
   }
 
   const onSearchClear = () => {
-    // reset searchQuery and sync with query parameter in route
-    router.push('/')
     setSearchQuery('')
   }
 
@@ -163,22 +159,12 @@ export const Search: React.FunctionComponent<Props> = () => {
 
   React.useEffect(() => {
     const typingDelay = setTimeout(() => {
-      try {
-        // only trigger search with at least one character as input
-        // otherwise reset search results
-        if (searchQuery.length > 0) {
-          refetch({ query: searchQuery, cursor: "", published: router.query.published as string, resourceTypeId: router.query['resource-type'] as string})
-        } else {
-          setSearchResults([])
-        }
-      } catch(e) {
-        console.log(e)
-      }
-    }, 300)
+      refetch({ query: searchQuery, cursor: "", published: published as string, resourceTypeId: resourceType as string, registrationAgency: registrationAgency as string })
+    }, 1000)
 
     let results: ContentNode[] = []
 
-    if (searchQuery.length > 0) {
+    if (searchQuery) {
       if (data) results = data.works.nodes
     }
     setSearchResults(results)
@@ -187,7 +173,7 @@ export const Search: React.FunctionComponent<Props> = () => {
   }, [searchQuery, data, refetch])
 
   const renderResults = () => {
-    if (searchQuery.length == 0) return (
+    if (!searchQuery) return (
       <div className="panel panel-transparent">
         <div className="panel-body">
           <h3 className="member">Introduction</h3>
@@ -252,21 +238,22 @@ export const Search: React.FunctionComponent<Props> = () => {
 
     function facetLink(param: string, value: string) {
       let url = '/?'
+      let icon = faSquare
+
       // get current query parameters from next router
-      // workaround as type definition does not seem to accept object
       let params = new URLSearchParams(router.query as any)
 
       if (params.get(param) == value) {
         // if param is present, delete from query and use checked icon
         params.delete(param)
-        url += params.toString()
-        return <Link href={url}><a><FontAwesomeIcon icon={faCheckSquare}/> </a></Link>
+        icon = faCheckSquare
       } else {
         // otherwise replace param with new value and use unchecked icon
         params.set(param, value)
-        url += params.toString() 
-        return <Link href={url}><a><FontAwesomeIcon icon={faSquare}/> </a></Link>
       }
+
+      url += params.toString() 
+      return <Link href={url}><a><FontAwesomeIcon icon={icon}/> </a></Link>
     }
 
     return (
@@ -327,13 +314,12 @@ export const Search: React.FunctionComponent<Props> = () => {
       </div>
     )
   }
-
   return (
     <div className="row">
       {renderFacets()}
       <div className="col-md-9 panel-list" id="content">
         <form className="form-horizontal search">
-        <input name="query" onChange={onSearchChange} value={searchQuery} placeholder="Type to search..." className="form-control" type="text" />
+          <input name="query" value={searchQuery || ''} onChange={onSearchChange} placeholder="Type to search..." className="form-control" type="text" />
           <span id="search-icon" title="Search" aria-label="Search">
             <FontAwesomeIcon icon={faSearch}/>
           </span>

--- a/cypress/integration/search.ts
+++ b/cypress/integration/search.ts
@@ -59,6 +59,18 @@ describe("Search", () => {
       // no facet for zero results
       .get('.panel.facets').should('not.exist')
   })
+
+  it("search with publication year facet", () => {
+    cy.get('input[name="query"]')
+      .type('hallett')
+      // timeout for the query results to return
+      .get('.member-results', { timeout: 10000 })
+      .should('contain', 'Results')
+      // no results count for zero results
+      .get('.member-results').should('not.exist')
+      // no facet for zero results
+      .get('.panel.facets').should('not.exist')
+  })
 })
 
 export {}

--- a/cypress/integration/search.ts
+++ b/cypress/integration/search.ts
@@ -63,13 +63,22 @@ describe("Search", () => {
   it("search with publication year facet", () => {
     cy.get('input[name="query"]')
       .type('hallett')
+      .get(':nth-child(2) > .panel-body > ul > :nth-child(2) > a', { timeout: 10000 })
+      .click()
       // timeout for the query results to return
-      .get('.member-results', { timeout: 10000 })
+      .get('.member-results')
       .should('contain', 'Results')
-      // no results count for zero results
-      .get('.member-results').should('not.exist')
-      // no facet for zero results
-      .get('.panel.facets').should('not.exist')
+      .get(':nth-child(3) > .panel-body > ul > :nth-child(1) > a').click()
+      // timeout for the query results to return
+      .get('.member-results')
+      .should('contain', 'Results')
+      // all facets are rendered
+      .get('.panel.facets').should(($facet) => {
+        expect($facet).to.have.length(3)
+        expect($facet.eq(0)).to.contain('Publication Year')
+        expect($facet.eq(1)).to.contain('Content Type')
+        expect($facet.eq(2)).to.contain('DOI Registration Agency')
+})
   })
 })
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "apollo-boost": "^0.4.9",
     "graphql": "^15.0.0",
     "next": "^9.4.1",
+    "next-usequerystate": "^1.1.0",
     "next-with-apollo": "^5.0.1",
     "node-fetch": "^2.6.0",
     "react": "^16.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8429,6 +8429,11 @@ next-tick@~1.0.0:
   resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"
   integrity sha1-yobR/ogoFpsBICCOPchCS524NCw=
 
+next-usequerystate@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/next-usequerystate/-/next-usequerystate-1.1.0.tgz#9e34ef76e93e39871047881c59ba0d6ef568c15b"
+  integrity sha512-jhFAlD4FbE8q3IlfvNefSs8ZNCEKgNy8pjbhnwh3k2cHVvo+iRJiJGg0+Rmki/i5rkVT2RhS2q2C+nXrtZCbCw==
+
 next-with-apollo@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/next-with-apollo/-/next-with-apollo-5.0.1.tgz#11055d834e98ad6dbdeb9c853afcfe421b5d4730"


### PR DESCRIPTION
## Purpose
Store state in the router to keep routes and state in sync.

## Approach
Using `next-usequerystate`. This simplifies syncing state and URL for queries. This pill request also fixes the "flicker" (running two queries) when faceting results

#### Open Questions and Pre-Merge TODOs
- [ ] Going forward we should evaluate `ApolloClient` to store state.
