### PR TITLE
License facet and display in GraphQL. #42

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ script:
   - yarn lint
   - yarn build
   - yarn start & wait-on http://localhost:3000
-  - yarn cy:run
+  - yarn cy:run --record
   - yarn cy:coverage
   - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
 

--- a/cypress/integration/doiContainer.test.ts
+++ b/cypress/integration/doiContainer.test.ts
@@ -1,17 +1,22 @@
 describe("DoiContainer", () => {
   beforeEach(() => {
-    cy.visit(`/dois/${encodeURIComponent('10.70048/q3sn-h087')}`)
+    cy.visit(`/dois/${encodeURIComponent('10.17863/cam.330')}`)
   })
 
-  it("visit 10.70048/q3sn-h087", () => {
+  it("visit 10.17863/cam.330", () => {
     cy.get('h3.work',  { timeout: 10000 })
-      .contains('Chandra X-ray Observatory ObsId 1')
+      .contains('Sugar Addiction: The State of the Science ')
+      .should('be.visible')
+  })
+
+  it("license", () => {
+    cy.get('.license a')
+      .should('have.attr', 'href').and('include', 'creativecommons.org')
       .should('be.visible')
   })
 
   it("export box", () => {
     cy.get('div#export-xml')
-      // timeout for the query results to return
       .contains('DataCite XML')
       .should('be.visible')
   })
@@ -23,5 +28,5 @@ describe("DoiContainer", () => {
       .get('.formatted-citation', { timeout: 10000 })
       .should('be.visible')
       //.contains('CXC-DS, “Chandra X-ray Observatory ObsId 1.”')
-      })
+  })
 })

--- a/cypress/integration/doiContainer.test.ts
+++ b/cypress/integration/doiContainer.test.ts
@@ -11,7 +11,7 @@ describe("DoiContainer", () => {
 
   it("license", () => {
     cy.get('.license a')
-      .should('have.attr', 'href').and('include', 'creativecommons.org')
+      .should('have.attr', 'href')
       .should('be.visible')
   })
 

--- a/cypress/integration/search.test.ts
+++ b/cypress/integration/search.test.ts
@@ -44,11 +44,11 @@ describe("Search", () => {
 
   it("search for specific doi", () => {
     cy.get('input[name="query"]')
-      .type('10.80225/da52-7919')
+      .type('10.17863/cam.330')
       // the results are rendered
       .get('.panel.content-item', { timeout: 20000 }).should(($contentItem) => {
         expect($contentItem).to.have.length(1)
-        expect($contentItem.eq(0)).to.contain('Version 1.0 of Content published 2020 via DataCite')
+        expect($contentItem.eq(0)).to.contain('Article published 2016 via Apollo - University of Cambridge Repository (staging)')
       })
       // no results count for single result
       .get('.member-results').should('not.exist')
@@ -81,16 +81,37 @@ describe("Search", () => {
       // timeout for the query results to return
       .get('.member-results')
       .should('contain', 'Results')
-      .get(':nth-child(3) > .panel-body > ul > :nth-child(1) > a').click()
+      .get(':nth-child(3) > .panel-body > ul > :nth-child(1) > a')
+      .click()
       // timeout for the query results to return
       .get('.member-results')
       .should('contain', 'Results')
       // all facets are rendered
       .get('.panel.facets').should(($facet) => {
-        expect($facet).to.have.length(3)
+        expect($facet).to.have.length(5)
         expect($facet.eq(0)).to.contain('Publication Year')
         expect($facet.eq(1)).to.contain('Content Type')
-        expect($facet.eq(2)).to.contain('DOI Registration Agency')
+        expect($facet.eq(2)).to.contain('Field of Science')
+        expect($facet.eq(3)).to.contain('License')
+        expect($facet.eq(4)).to.contain('DOI Registration Agency')
+      })
+  })
+
+  it("search and filter by license", () => {
+    cy.get('input[name="query"]')
+      .type('science')
+      .get(':nth-child(2) > .panel-body > ul > :nth-child(4) > a', { timeout: 20000 })
+      .click()
+      .get('.member-results')
+      .should('contain', 'Results')
+      // all facets are rendered
+      .get('.panel.facets').should(($facet) => {
+        expect($facet).to.have.length(5)
+        expect($facet.eq(0)).to.contain('Publication Year')
+        expect($facet.eq(1)).to.contain('Content Type')
+        expect($facet.eq(2)).to.contain('Field of Science')
+        expect($facet.eq(3)).to.contain('License')
+        expect($facet.eq(4)).to.contain('DOI Registration Agency')
       })
   })
 

--- a/cypress/integration/search.test.ts
+++ b/cypress/integration/search.test.ts
@@ -57,8 +57,8 @@ describe("Search", () => {
         expect($facet).to.have.length(4)
         expect($facet.eq(0)).to.contain('Publication Year')
         expect($facet.eq(1)).to.contain('Content Type')
-        expect($facet.eq(1)).to.contain('License')
-        expect($facet.eq(2)).to.contain('DOI Registration Agency')
+        expect($facet.eq(2)).to.contain('License')
+        expect($facet.eq(3)).to.contain('DOI Registration Agency')
       })
   })
 

--- a/cypress/integration/search.test.ts
+++ b/cypress/integration/search.test.ts
@@ -54,9 +54,10 @@ describe("Search", () => {
       .get('.member-results').should('not.exist')
       // all facets are rendered
       .get('.panel.facets').should(($facet) => {
-        expect($facet).to.have.length(3)
+        expect($facet).to.have.length(4)
         expect($facet.eq(0)).to.contain('Publication Year')
         expect($facet.eq(1)).to.contain('Content Type')
+        expect($facet.eq(1)).to.contain('License')
         expect($facet.eq(2)).to.contain('DOI Registration Agency')
       })
   })

--- a/src/components/DoiContainer/DoiContainer.tsx
+++ b/src/components/DoiContainer/DoiContainer.tsx
@@ -36,6 +36,7 @@ export const DOI_GQL = gql`
   	rights{
       rights
       rightsUri
+      rightsIdentifier
     }
     id
     doi
@@ -114,8 +115,6 @@ interface Rights {
   rights: string
   rightsUri: string
   rightsIdentifier: string
-  rightsIdentifierScheme: string
-  schemeUri: string
 }
 
 interface Description {

--- a/src/components/DoiMetadata/DoiMetadata.tsx
+++ b/src/components/DoiMetadata/DoiMetadata.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { Popover, OverlayTrigger, Alert } from 'react-bootstrap'
 import startCase from 'lodash/startCase'
 import truncate from 'lodash/truncate'
+import uniqBy from 'lodash/uniqBy'
 import Pluralize from 'react-pluralize'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { 
@@ -14,7 +15,15 @@ import {
 import { 
   faEye
 } from '@fortawesome/free-regular-svg-icons'
-import { faOrcid } from '@fortawesome/free-brands-svg-icons'
+import { 
+  faOrcid,
+  faCreativeCommons,
+  faCreativeCommonsBy,
+  faCreativeCommonsNc,
+  faCreativeCommonsNd,
+  faCreativeCommonsSa,
+  faCreativeCommonsZero
+} from '@fortawesome/free-brands-svg-icons'
 import ReactHtmlParser from 'react-html-parser'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
@@ -131,6 +140,69 @@ const DoiMetadata: React.FunctionComponent<Props> = ({item}) => {
     )
   }
 
+  const license = () => {
+    const uniqueRights = uniqBy(item.rights, 'rightsIdentifier')
+    const ccRights = uniqueRights.reduce((sum, r) => {
+      if (r.rightsIdentifier && r.rightsIdentifier.startsWith('cc')) {
+        const splitIdentifier = r.rightsIdentifier.split('-').filter(l => ['cc', 'cc0', 'by', 'nc', 'nd', 'sa'].includes(l) )
+        splitIdentifier.forEach(l => {
+          switch(l) {
+            case 'by':
+              sum.push({ icon: faCreativeCommonsBy, rightsUri: r.rightsUri, rightsIdentifier: r.rightsIdentifier })
+              break;
+            case 'nc':
+              sum.push({ icon: faCreativeCommonsNc, rightsUri: r.rightsUri, rightsIdentifier: r.rightsIdentifier })
+              break;
+            case 'nd':
+              sum.push({ icon: faCreativeCommonsNd, rightsUri: r.rightsUri, rightsIdentifier: r.rightsIdentifier })
+              break;
+            case 'sa':
+              sum.push({ icon: faCreativeCommonsSa, rightsUri: r.rightsUri, rightsIdentifier: r.rightsIdentifier })
+              break;
+            case 'cc0':
+              sum.push({ icon: faCreativeCommons, rightsUri: r.rightsUri, rightsIdentifier: r.rightsIdentifier })
+              sum.push({ icon: faCreativeCommonsZero, rightsUri: r.rightsUri, rightsIdentifier: r.rightsIdentifier })
+              break;
+            default:
+              sum.push({ icon: faCreativeCommons, rightsUri: r.rightsUri, rightsIdentifier: r.rightsIdentifier })
+          }
+        })
+      }
+      return sum
+    }, [])
+
+    const otherRights = uniqueRights.reduce((sum, r) => {
+      if (r.rightsIdentifier && !r.rightsIdentifier.startsWith('cc')) {
+        if (r.rightsIdentifier.startsWith('apache')) {
+          r.rightsIdentifier = "Apache%202.0"
+        } else if (r.rightsIdentifier.startsWith('ogl')) {
+            r.rightsIdentifier = "OGL%20Canada"
+        } else {
+          r.rightsIdentifier = r.rightsIdentifier.replace(/-/g, '%20').toUpperCase()
+        } 
+        sum.push(r)
+      }
+      return sum
+    }, [])
+
+    if (!ccRights[0] && !otherRights[0]) return ''
+
+    return (
+      <div className="license">
+        {ccRights.map((r, index) =>
+          <a href={r.rightsUri} key={index} target="_blank" rel="noreferrer">
+            <FontAwesomeIcon key={r.rightsIdentifier} icon={r.icon} />
+          </a>
+        )}
+        {otherRights.map((r) =>
+          <a href={r.rightsUri} key={r.rightsIdentifier} target="_blank" rel="noreferrer">
+            <img src={`https://img.shields.io/badge/license-${r.rightsIdentifier}-blue.svg`} />
+          </a>
+        )}
+      </div>
+    )
+  }
+
   const metricsCounter = () => {
     if (item.citationCount + item.viewCount + item.downloadCount == 0) {
       return (
@@ -170,16 +242,16 @@ const DoiMetadata: React.FunctionComponent<Props> = ({item}) => {
   const links = () => {
     return (
       <div className="panel-footer">
-      <a href={item.id}><FontAwesomeIcon icon={faExternalLinkAlt}/> {item.id}</a>
-      <span className="actions">
-        <OverlayTrigger trigger="click" placement="top" overlay={bookmark}>
-          <span className="bookmark"><FontAwesomeIcon icon={faBookmark}/> Bookmark</span>
-        </OverlayTrigger>
-        <OverlayTrigger trigger="click" placement="top" overlay={claim}>
-          <span className="claim"><FontAwesomeIcon icon={faOrcid}/> Claim</span>
-      </OverlayTrigger>
-      </span>
-    </div>
+        <a href={item.id}><FontAwesomeIcon icon={faExternalLinkAlt}/> {item.id}</a>
+        <span className="actions">
+          <OverlayTrigger trigger="click" placement="top" overlay={bookmark}>
+            <span className="bookmark"><FontAwesomeIcon icon={faBookmark}/> Bookmark</span>
+          </OverlayTrigger>
+          <OverlayTrigger trigger="click" placement="top" overlay={claim}>
+            <span className="claim"><FontAwesomeIcon icon={faOrcid}/> Claim</span>
+          </OverlayTrigger>
+        </span>
+      </div>
     )
   }
 
@@ -190,6 +262,7 @@ const DoiMetadata: React.FunctionComponent<Props> = ({item}) => {
         {creators()}
         {metadata()}
         {description()}
+        {license()}
         {metricsCounter()}
       </div>
         {links()}

--- a/src/components/DoiMetadata/DoiMetadata.tsx
+++ b/src/components/DoiMetadata/DoiMetadata.tsx
@@ -193,6 +193,9 @@ const DoiMetadata: React.FunctionComponent<Props> = ({item}) => {
             <img src={`https://img.shields.io/badge/license-${r.rightsIdentifier}-blue.svg`} />
           </a>
         )}
+      </div>
+    )
+  }
 
   const registered = () => {
     return (

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -49,6 +49,7 @@ interface ContentQueryVar {
   published: string
   resourceTypeId: string
   fieldOfScience: string
+  license: string
   registrationAgency: string
 }
 

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -37,6 +37,7 @@ interface ContentQueryData {
       published: ContentFacet[]
       resourceTypes: ContentFacet[]
       fieldsOfScience: ContentFacet[]
+      licenses: ContentFacet[]
       registrationAgencies: ContentFacet[]
       totalCount: Number
   },
@@ -52,8 +53,8 @@ interface ContentQueryVar {
 }
 
 export const CONTENT_GQL = gql`
-  query getContentQuery($query: String, $cursor: String, $published: String, $resourceTypeId: String, $fieldOfScience: String, $registrationAgency: String) {
-    works(first: 25, query: $query, after: $cursor, published: $published, resourceTypeId: $resourceTypeId, fieldOfScience: $fieldOfScience, registrationAgency: $registrationAgency) {
+  query getContentQuery($query: String, $cursor: String, $published: String, $resourceTypeId: String, $fieldOfScience: String, $license: String, $registrationAgency: String) {
+    works(first: 25, query: $query, after: $cursor, published: $published, resourceTypeId: $resourceTypeId, fieldOfScience: $fieldOfScience, license: $license, registrationAgency: $registrationAgency) {
       totalCount
       pageInfo {
         endCursor
@@ -70,6 +71,11 @@ export const CONTENT_GQL = gql`
         count
       }
       fieldsOfScience {
+        id
+        title
+        count
+      }
+      licenses {
         id
         title
         count
@@ -102,6 +108,11 @@ export const CONTENT_GQL = gql`
         publicationYear
         publisher
         version
+        rights {
+          rights
+          rightsUri
+          rightsIdentifier
+        }
         registrationAgency
         citationCount
         viewCount
@@ -117,7 +128,8 @@ export const Search: React.FunctionComponent = () => {
   /* eslint-disable no-unused-vars */
   const [published, setPublished] = useQueryState('published', { history: 'push' })
   const [resourceType, setResourceType] = useQueryState('resource-type', { history: 'push' })
-  const [fieldOfScience, setfieldOfScience] = useQueryState('field-of-science', { history: 'push' })
+  const [fieldOfScience, setFieldOfScience] = useQueryState('field-of-science', { history: 'push' })
+  const [license, setLicense] = useQueryState('license', { history: 'push' })
   const [registrationAgency, setRegistrationAgency] = useQueryState('registration-agency', { history: 'push' })
   const [cursor, setCursor] = useQueryState('cursor', { history: 'push' })
   /* eslint-enable no-unused-vars */
@@ -126,7 +138,7 @@ export const Search: React.FunctionComponent = () => {
     CONTENT_GQL,
     {
       errorPolicy: 'all',
-      variables: { query: searchQuery, cursor: cursor, published: published as string, resourceTypeId: resourceType as string, fieldOfScience: fieldOfScience as string, registrationAgency: registrationAgency as string }
+      variables: { query: searchQuery, cursor: cursor, published: published as string, resourceTypeId: resourceType as string, fieldOfScience: fieldOfScience as string, license: license as string, registrationAgency: registrationAgency as string }
     }
   )
 
@@ -178,7 +190,7 @@ export const Search: React.FunctionComponent = () => {
 
   React.useEffect(() => {
     const typingDelay = setTimeout(() => {
-      refetch({ query: searchQuery, cursor: cursor, published: published as string, resourceTypeId: resourceType as string, fieldOfScience: fieldOfScience as string, registrationAgency: registrationAgency as string })
+      refetch({ query: searchQuery, cursor: cursor, published: published as string, resourceTypeId: resourceType as string, fieldOfScience: fieldOfScience as string, license: license as string, registrationAgency: registrationAgency as string })
     }, 1000)
 
     let results: ContentNode[] = []
@@ -334,6 +346,24 @@ export const Search: React.FunctionComponent = () => {
                 {data.works.fieldsOfScience.map(facet => (
                   <li key={facet.id}>
                     {facetLink('field-of-science', facet.id)}
+                    <div className="facet-title">{facet.title}</div>
+                    <span className="number pull-right">{facet.count.toLocaleString('en-US')}</span>
+                    <div className="clearfix"/>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        }
+
+        {data.works.licenses.length > 0 &&
+          <div className="panel facets add">
+            <div className="panel-body">
+              <h4>License</h4>
+              <ul>
+                {data.works.licenses.map(facet => (
+                  <li key={facet.id}>
+                    {facetLink('license', facet.id)}
                     <div className="facet-title">{facet.title}</div>
                     <span className="number pull-right">{facet.count.toLocaleString('en-US')}</span>
                     <div className="clearfix"/>

--- a/src/styles.css
+++ b/src/styles.css
@@ -115,3 +115,10 @@ input[type=text] {
 .work span.small {
   color: #88939a;
 }
+
+.license svg {
+  font-size: 27px;
+  margin-top: 3px;
+  margin-right: 3px;
+  margin-bottom: 3px;
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -121,6 +121,7 @@ input[type=text] {
   margin-top: 3px;
   margin-right: 3px;
   margin-bottom: 3px;
+}
 
 .tags .label {
   margin-top: 2px;


### PR DESCRIPTION
## Purpose
Add a license facet and display license for each content item.

## Approach
Licenses are normalized in the GraphQL API using SPDX. 
