### PR TITLE
Display language facet and tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ script:
   - yarn lint
   - yarn build
   - yarn start & wait-on http://localhost:3000
-  - yarn cy:run
+  - yarn cy:run --record
   - yarn cy:coverage
   - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
 

--- a/cypress/integration/doiContainer.test.ts
+++ b/cypress/integration/doiContainer.test.ts
@@ -4,13 +4,13 @@ describe("DoiContainer", () => {
   })
 
   it("visit 10.70048/q3sn-h087", () => {
-    cy.get('h3.work',  { timeout: 10000 })
+    cy.get('h3.work', { timeout: 30000 })
       .contains('Chandra X-ray Observatory ObsId 1')
       .should('be.visible')
   })
 
   it("export box", () => {
-    cy.get('div#export-xml')
+    cy.get('div#export-xml', { timeout: 30000 })
       // timeout for the query results to return
       .contains('DataCite XML')
       .should('be.visible')
@@ -20,7 +20,7 @@ describe("DoiContainer", () => {
     cy.get('select.cite-as')
       .select('ieee')
       // timeout for the query results to return
-      .get('.formatted-citation', { timeout: 10000 })
+      .get('.formatted-citation', { timeout: 30000 })
       .should('be.visible')
       //.contains('CXC-DS, “Chandra X-ray Observatory ObsId 1.”')
       })

--- a/cypress/integration/search.test.ts
+++ b/cypress/integration/search.test.ts
@@ -14,7 +14,7 @@ describe("Search", () => {
     cy.get('input[name="query"]')
       .type('richard hallett')
       // timeout for the query results to return
-      .get('.member-results', { timeout: 20000 })
+      .get('.member-results', { timeout: 30000 })
       .should('contain', 'Results')
       // results are rendered
       .get('.panel.content-item').should(($contentItem) => {
@@ -36,7 +36,7 @@ describe("Search", () => {
     cy.get('input[name="query"]')
       .type('hallett')
       // timeout for the query results to return
-      .get('.member-results', { timeout: 20000 })
+      .get('.member-results', { timeout: 30000 })
       // results are found
       .should('contain', 'Results')
       .get('#search-clear >').click()
@@ -49,7 +49,7 @@ describe("Search", () => {
     cy.get('input[name="query"]')
       .type('10.80225/da52-7919')
       // the results are rendered
-      .get('.panel-body .metadata', { timeout: 20000 })
+      .get('.panel-body .metadata', { timeout: 30000 })
       .should('contain', 'Version 1.0 of Content published 2020 via DataCite' )
       .get('.panel-body .creators')
       .should('contain', 'Matt Buys, Robin Dasler & Martin Fenner')
@@ -74,7 +74,7 @@ describe("Search", () => {
     cy.get('input[name="query"]')
       .type('xxxxxxxxxxxx')
       // timeout for the query results to return
-      .get('.alert-warning', { timeout: 20000 })
+      .get('.alert-warning', { timeout: 30000 })
       .should('contain', 'No content found.')
       // no results count for zero results
       .get('.member-results').should('not.exist')
@@ -85,7 +85,7 @@ describe("Search", () => {
   it("search and use facets", () => {
     cy.get('input[name="query"]')
       .type('hallett')
-      .get(':nth-child(2) > .panel-body > ul > :nth-child(2) > a', { timeout: 20000 })
+      .get(':nth-child(2) > .panel-body > ul > :nth-child(2) > a', { timeout: 30000 })
       .click()
       // timeout for the query results to return
       .get('.member-results')
@@ -106,11 +106,11 @@ describe("Search", () => {
   it("search with pagination", () => {
     cy.get('input[name="query"]')
       .type('hallett')
-      .get('.member-results', { timeout: 10000 })
+      .get('.member-results', { timeout: 30000 })
       .should('contain', 'Results')
       .get('.page-number > a').click()
       // timeout for the query results to return
-      .get('.member-results', { timeout: 10000 })
+      .get('.member-results', { timeout: 30000 })
       .should('contain', 'Results')
       // all facets are rendered
       .get('.panel.facets').should(($facet) => {

--- a/cypress/integration/search.test.ts
+++ b/cypress/integration/search.test.ts
@@ -14,7 +14,7 @@ describe("Search", () => {
     cy.get('input[name="query"]')
       .type('richard hallett')
       // timeout for the query results to return
-      .get('.member-results', { timeout: 30000 })
+      .get('.member-results', { timeout: 60000 })
       .should('contain', 'Results')
       // results are rendered
       .get('.panel.content-item').should(($contentItem) => {
@@ -36,7 +36,7 @@ describe("Search", () => {
     cy.get('input[name="query"]')
       .type('hallett')
       // timeout for the query results to return
-      .get('.member-results', { timeout: 30000 })
+      .get('.member-results', { timeout: 60000 })
       // results are found
       .should('contain', 'Results')
       .get('#search-clear >').click()
@@ -49,7 +49,7 @@ describe("Search", () => {
     cy.get('input[name="query"]')
       .type('10.80225/da52-7919')
       // the results are rendered
-      .get('.panel-body .metadata', { timeout: 30000 })
+      .get('.panel-body .metadata', { timeout: 60000 })
       .should('contain', 'Version 1.0 of Content published 2020 via DataCite' )
       .get('.panel-body .creators')
       .should('contain', 'Matt Buys, Robin Dasler & Martin Fenner')
@@ -74,7 +74,7 @@ describe("Search", () => {
     cy.get('input[name="query"]')
       .type('xxxxxxxxxxxx')
       // timeout for the query results to return
-      .get('.alert-warning', { timeout: 30000 })
+      .get('.alert-warning', { timeout: 60000 })
       .should('contain', 'No content found.')
       // no results count for zero results
       .get('.member-results').should('not.exist')
@@ -85,7 +85,7 @@ describe("Search", () => {
   it("search and use facets", () => {
     cy.get('input[name="query"]')
       .type('hallett')
-      .get(':nth-child(2) > .panel-body > ul > :nth-child(2) > a', { timeout: 30000 })
+      .get(':nth-child(2) > .panel-body > ul > :nth-child(2) > a', { timeout: 60000 })
       .click()
       // timeout for the query results to return
       .get('.member-results')
@@ -106,11 +106,11 @@ describe("Search", () => {
   it("search with pagination", () => {
     cy.get('input[name="query"]')
       .type('hallett')
-      .get('.member-results', { timeout: 30000 })
+      .get('.member-results', { timeout: 60000 })
       .should('contain', 'Results')
       .get('.page-number > a').click()
       // timeout for the query results to return
-      .get('.member-results', { timeout: 30000 })
+      .get('.member-results', { timeout: 60000 })
       .should('contain', 'Results')
       // all facets are rendered
       .get('.panel.facets').should(($facet) => {

--- a/cypress/integration/search.test.ts
+++ b/cypress/integration/search.test.ts
@@ -10,22 +10,25 @@ describe("Search", () => {
       .should('contain', 'Introduction')
   })
 
-  it("search for hallett", () => {
+  it("search for richard hallett", () => {
     cy.get('input[name="query"]')
-      .type('hallett')
+      .type('richard hallett')
       // timeout for the query results to return
       .get('.member-results', { timeout: 20000 })
       .should('contain', 'Results')
       // results are rendered
       .get('.panel.content-item').should(($contentItem) => {
-        expect($contentItem).to.have.length(25)
+        expect($contentItem).to.have.length(13)
       })
+      .get(':nth-child(2) > .panel-body > .registered')
+      .should('contain', 'DOI registered')
       // all facets are rendered
       .get('.panel.facets').should(($facet) => {
-        expect($facet).to.have.length(3)
+        expect($facet).to.have.length(4)
         expect($facet.eq(0)).to.contain('Publication Year')
         expect($facet.eq(1)).to.contain('Content Type')
-        expect($facet.eq(2)).to.contain('DOI Registration Agency')
+        expect($facet.eq(2)).to.contain('Language')
+        expect($facet.eq(3)).to.contain('DOI Registration Agency')
       })
   })
 
@@ -46,10 +49,16 @@ describe("Search", () => {
     cy.get('input[name="query"]')
       .type('10.80225/da52-7919')
       // the results are rendered
-      .get('.panel.content-item', { timeout: 20000 }).should(($contentItem) => {
-        expect($contentItem).to.have.length(1)
-        expect($contentItem.eq(0)).to.contain('Version 1.0 of Content published 2020 via DataCite')
-      })
+      .get('.panel-body .metadata', { timeout: 20000 })
+      .should('contain', 'Version 1.0 of Content published 2020 via DataCite' )
+      .get('.panel-body .creators')
+      .should('contain', 'Matt Buys, Robin Dasler & Martin Fenner')
+      .get('.panel-body .registered')
+      .should('contain', 'DOI registered March 19, 2020 via DataCite.')
+      .get('.panel-body .description')
+      .should('contain', 'As a community-driven organization')
+      .get('.panel-body .tags')
+      .should('contain', 'Interactive Resource')
       // no results count for single result
       .get('.member-results').should('not.exist')
       // all facets are rendered
@@ -105,10 +114,11 @@ describe("Search", () => {
       .should('contain', 'Results')
       // all facets are rendered
       .get('.panel.facets').should(($facet) => {
-        expect($facet).to.have.length(3)
+        expect($facet).to.have.length(4)
         expect($facet.eq(0)).to.contain('Publication Year')
         expect($facet.eq(1)).to.contain('Content Type')
-        expect($facet.eq(2)).to.contain('DOI Registration Agency')
+        expect($facet.eq(2)).to.contain('Language')
+        expect($facet.eq(3)).to.contain('DOI Registration Agency')
       })
   })
 })

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "babel-preset-env": "^1.7.0",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",
-    "cypress": "4.9.0",
+    "cypress": "^4.9.0",
     "cypress-react-unit-test": "^4.4.2",
     "eslint": "^7.2.0",
     "eslint-config-airbnb": "^18.1.0",

--- a/src/components/Doi/Doi.test.tsx
+++ b/src/components/Doi/Doi.test.tsx
@@ -13,6 +13,8 @@ const data = {
   publisher: "SURFsara",
   publicationYear: 2019,
   version: "1.0",
+  registered: "2019-12-19T12:43:12Z",
+  registrationAgency: { id: "datacite", name: "DataCite" },
   formattedCitation: "Gallardo-Escárate, C., Valenzuela-Muñoz, V., Núñez-Acuña, G., &amp; Haye, P. (2014). <i>Data from: SNP discovery and gene annotation in the surf clam Mesodesma donacium</i> (Version 1) [Data set]. Dryad. <a href='https://doi.org/10.5061/DRYAD.8JD18'>https://doi.org/10.5061/DRYAD.8JD18</a>",
   citationCount: 4,
   viewCount: 8,
@@ -28,7 +30,7 @@ describe('DoiMetadata Component', () => {
   it('title', () => {
     mount(<Doi item={data}/>)
     cy.get('h3.work')
-      .contains('Example title of the item Dataset')
+      .contains('Example title of the item')
       .should('be.visible')
   })
   
@@ -50,6 +52,13 @@ describe('DoiMetadata Component', () => {
     mount(<Doi item={data}/>)
     cy.get('.description')
       .contains('Example description of the item.')
+      .should('be.visible')
+  })
+
+  it('registered', () => {
+    mount(<Doi item={data}/>)
+    cy.get('.registered')
+      .contains('DOI registered December 19, 2019')
       .should('be.visible')
   })
 

--- a/src/components/Doi/Doi.tsx
+++ b/src/components/Doi/Doi.tsx
@@ -17,8 +17,8 @@ type Props = {
 const DoiPresentation: React.FunctionComponent<Props> = ({item}) => {
   if (!item ) return (
     <Alert bsStyle="warning">
-        No content found.
-      </Alert>
+      No content found.
+    </Alert>
   )
   
   const formattedCitation = () => { 
@@ -54,27 +54,26 @@ const DoiPresentation: React.FunctionComponent<Props> = ({item}) => {
   const downloadsTabLabel = Pluralize({count: compactNumbers(item.downloadCount), singular:'Download', style:style, showCount:true}) 
  
   const analyticsBar = () => {
-
     return (
       <div className="panel panel-transparent">
-          <div className="panel-body tab-content nav-tabs-member">
-        <Tabs  id="over-time-tabs">
-          {item.citationCount > 0 && 
-            <Tab className="citations-over-time-tab" eventKey="citationsOverTime" title={citationsTabLabel}>
-              <CitationsChart data={item.citationsOverTime} publicationYear={item.publicationYear} citationCount={item.citationCount}></CitationsChart>
-            </Tab>
-          }
-          {item.viewCount > 0 && 
-            <Tab className="views-over-time-tab" eventKey="viewsOverTime" title={viewsTabLabel}>
-              <UsageChart data={item.viewsOverTime} counts={item.viewCount} publicationYear={item.publicationYear} type="View"/> 
-            </Tab>
-          }
-          {item.downloadCount > 0 && 
-            <Tab className="downloads-over-time-tab" eventKey="downloadsOverTime" title={downloadsTabLabel}>
-              <UsageChart data={item.downloadsOverTime} counts={item.downloadCount} publicationYear={item.publicationYear} type="Download" />
-            </Tab>
-          }
-        </Tabs>
+        <div className="panel-body tab-content nav-tabs-member">
+          <Tabs  id="over-time-tabs">
+            {item.citationCount > 0 && 
+              <Tab className="citations-over-time-tab" eventKey="citationsOverTime" title={citationsTabLabel}>
+                <CitationsChart data={item.citationsOverTime} publicationYear={item.publicationYear} citationCount={item.citationCount}></CitationsChart>
+              </Tab>
+            }
+            {item.viewCount > 0 && 
+              <Tab className="views-over-time-tab" eventKey="viewsOverTime" title={viewsTabLabel}>
+                <UsageChart data={item.viewsOverTime} counts={item.viewCount} publicationYear={item.publicationYear} type="View"/> 
+              </Tab>
+            }
+            {item.downloadCount > 0 && 
+              <Tab className="downloads-over-time-tab" eventKey="downloadsOverTime" title={downloadsTabLabel}>
+                <UsageChart data={item.downloadsOverTime} counts={item.downloadCount} publicationYear={item.publicationYear} type="Download" />
+              </Tab>
+            }
+          </Tabs>
         </div>
       </div>
     )
@@ -82,38 +81,37 @@ const DoiPresentation: React.FunctionComponent<Props> = ({item}) => {
 
 // eslint-disable-next-line no-unused-vars
   const relatedContent = () => {
-
     const referencesTabLabel = Pluralize({count: compactNumbers(item.references.nodes.length), singular:'Reference', style:style,showCount:true}) 
     const citationsTabLabel = Pluralize({count: compactNumbers(item.citations.nodes.length), singular:'Citation', style:style,showCount:true}) 
 
     return (
       <div className="panel panel-transparent">
-      <div className="panel-body tab-content nav-tabs-member">
-    <Tabs id="related-content-tabs">
-    {item.citations.nodes.length > 0 && 
-      <Tab className="citations-list" eventKey="citationsList" title={citationsTabLabel}>
-        {/* <RelatedContentList dataInput={item.citations} /> */}
-        <p>This feature will be implemented later in 2020. <a href="https://portal.productboard.com/71qotggkmbccdwzokuudjcsb/c/35-common-doi-search" target="_blank" rel="noreferrer">Provide input</a></p>
+        <div className="panel-body tab-content nav-tabs-member">
+          <Tabs id="related-content-tabs">
+            {item.citations.nodes.length > 0 && 
+              <Tab className="citations-list" eventKey="citationsList" title={citationsTabLabel}>
+                {/* <RelatedContentList dataInput={item.citations} /> */}
+                <p>This feature will be implemented later in 2020. <a href="https://portal.productboard.com/71qotggkmbccdwzokuudjcsb/c/35-common-doi-search" target="_blank" rel="noreferrer">Provide input</a></p>
 
-      </Tab>
-    }
-     {item.references.nodes.length > 0 && 
-      <Tab className="references-list" eventKey="referencesList" title={referencesTabLabel}>
-        {/* <RelatedContentList dataInput={item.references} /> */}
-        <p>This feature will be implemented later in 2020. <a href="https://portal.productboard.com/71qotggkmbccdwzokuudjcsb/c/35-common-doi-search" target="_blank" rel="noreferrer">Provide input</a></p>
+              </Tab>
+            }
+            {item.references.nodes.length > 0 && 
+              <Tab className="references-list" eventKey="referencesList" title={referencesTabLabel}>
+                {/* <RelatedContentList dataInput={item.references} /> */}
+                <p>This feature will be implemented later in 2020. <a href="https://portal.productboard.com/71qotggkmbccdwzokuudjcsb/c/35-common-doi-search" target="_blank" rel="noreferrer">Provide input</a></p>
 
-       </Tab>
-    }
-     </Tabs>
-     </div>
-   </div>
-     )
-   }
+              </Tab>
+            }
+          </Tabs>
+        </div>
+      </div>
+    )
+  }
 
   return (
     <div key={item.id} className="panel panel-transparent">
       <h2 className="member-results">{item.doi}</h2>
-        <DoiMetadata item={item}></DoiMetadata>
+      <DoiMetadata item={item}></DoiMetadata>
       <br/>
       {formattedCitation()}
       {analyticsBar()}

--- a/src/components/DoiContainer/DoiContainer.tsx
+++ b/src/components/DoiContainer/DoiContainer.tsx
@@ -14,6 +14,8 @@ type Props = {
 export const DOI_GQL = gql`
   query getContentQuery($id: ID!) {
   work(id: $id){
+    id
+    doi
     titles{
       title
     }
@@ -30,15 +32,26 @@ export const DOI_GQL = gql`
     version
     publicationYear
     publisher
-    descriptions{
+    descriptions {
       description
     }
-  	rights{
+  	rights {
       rights
       rightsUri
     }
-    id
-    doi
+    fieldsOfScience {
+      id
+      name
+    }
+    language {
+      id
+      name
+    }
+    registrationAgency {
+      id
+      name
+    }
+    registered
     formattedCitation
     citationCount
     citationsOverTime {
@@ -82,8 +95,18 @@ export interface DoiType {
   publicationYear: number
   publisher: string
   descriptions?: Description[]
+  fieldsOfScience?: FieldOfScience[]
   rights?: Rights[]
   version?: string
+  language?: {
+    id: string
+    name: string
+  }
+  registrationAgency: {
+    id: string
+    name: string
+  }
+  registered?: Date
   formattedCitation?: string
   citationCount?: number
   citationsOverTime?: CitationsYear[]
@@ -116,6 +139,11 @@ interface Rights {
   rightsIdentifier: string
   rightsIdentifierScheme: string
   schemeUri: string
+}
+
+interface FieldOfScience{
+  id: string
+  name: string
 }
 
 interface Description {
@@ -196,7 +224,6 @@ const DoiContainer: React.FunctionComponent<Props> = ({item}) => {
   if (!doi ) return <p>Content not found.</p>
 
   const leftSideBar = () => {
-
     const facebook = (
       <Popover id="share" title="Sharing via Facebook">
          Sharing via social media will be implemented later in 2020. <a href="https://portal.productboard.com/71qotggkmbccdwzokuudjcsb/c/35-common-doi-search" target="_blank" rel="noreferrer">Provide input</a>
@@ -208,7 +235,6 @@ const DoiContainer: React.FunctionComponent<Props> = ({item}) => {
         Sharing via social media will be implemented later in 2020. <a href="https://portal.productboard.com/71qotggkmbccdwzokuudjcsb/c/35-common-doi-search" target="_blank" rel="noreferrer">Provide input</a>
       </Popover>
     )
-
 
     return (
       <div className="col-md-3 hidden-xs hidden-sm">
@@ -239,23 +265,22 @@ const DoiContainer: React.FunctionComponent<Props> = ({item}) => {
               <a target="_blank" rel="noopener" href={process.env.NEXT_PUBLIC_API_URL + "/dois/application/x-bibtex/" +
                 doi.doi}>BibTeX</a>
             </div>
-            <div id="export-bibtex" className="download">
+            <div id="export-ris" className="download">
               <a target="_blank" rel="noopener" href={process.env.NEXT_PUBLIC_API_URL
                 + "/dois/application/x-research-info-systems/" + doi.doi}>RIS</a>
             </div>
-            <div id="export-bibtex" className="download">
+            <div id="export-jats" className="download">
               <a target="_blank" rel="noopener" href={process.env.NEXT_PUBLIC_API_URL
                 + "/dois/application/vnd.jats+xml/" + doi.doi}>JATS</a>
             </div>
             { doi.types.resourceTypeGeneral === "Software" &&
-            <div id="export-bibtex" className="download">
-              <a target="_blank" rel="noopener" href={process.env.NEXT_PUBLIC_API_URL
-                + "/dois/application/vnd.codemeta.ld+json/" + doi.doi}>Codemeta</a>
-            </div>
+              <div id="export-codemeta" className="download">
+                <a target="_blank" rel="noopener" href={process.env.NEXT_PUBLIC_API_URL
+                  + "/dois/application/vnd.codemeta.ld+json/" + doi.doi}>Codemeta</a>
+              </div>
             }
           </div>
           <div className="facets panel-body">
-
             <h4>Share</h4>
             <span className="actions">
             <OverlayTrigger  placement="top" overlay={facebook}>

--- a/src/components/DoiMetadata/DoiMetadata.test.tsx
+++ b/src/components/DoiMetadata/DoiMetadata.test.tsx
@@ -22,6 +22,8 @@ let exampleItem = {
     rightsIdentifierScheme: 'SPDX',
     schemeUri: 'https://spdx.org/licenses/',
   }],
+  registrationAgency: { id: 'datacite', name: 'DataCite' },
+  language: { id: 'fr', name: 'French' },
   citationCount: 4,
   citationsOverTime: [{ total: 4, year: 2020 }],
   viewCount: 8,

--- a/src/components/DoiMetadata/DoiMetadata.test.tsx
+++ b/src/components/DoiMetadata/DoiMetadata.test.tsx
@@ -34,7 +34,7 @@ describe('DoiMetadata Component', () => {
   it('title', () => {
     mount(<DoiMetadata item={exampleItem}/>)
     cy.get('h3.work')
-      .contains('Example title of the item Dataset')
+      .contains('Example title of the item')
       .should('be.visible')
   })
   
@@ -64,6 +64,13 @@ describe('DoiMetadata Component', () => {
     mount(<DoiMetadata item={exampleItem}/>)
     cy.get('.description')
       .contains('Example description of the item.')
+      .should('be.visible')
+  })
+
+  it('tags', () => {
+    mount(<DoiMetadata item={exampleItem}/>)
+    cy.get('.tags')
+      .contains('French')
       .should('be.visible')
   })
 

--- a/src/components/DoiMetadata/DoiMetadata.tsx
+++ b/src/components/DoiMetadata/DoiMetadata.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { Popover, OverlayTrigger, Alert } from 'react-bootstrap'
+import { Popover, OverlayTrigger, Alert, Label, Tooltip } from 'react-bootstrap'
 import startCase from 'lodash/startCase'
 import truncate from 'lodash/truncate'
 import Pluralize from 'react-pluralize'
@@ -49,9 +49,6 @@ const DoiMetadata: React.FunctionComponent<Props> = ({item}) => {
         <Link href="/dois/[doi]" as={`/dois/${encodeURIComponent(item.doi)}`}>
           <a>{ReactHtmlParser(titleHtml)}</a>
         </Link>
-        {item.types.resourceTypeGeneral &&
-          <span className="small"> {startCase(item.types.resourceTypeGeneral)}</span>
-        }
       </h3>
     )
   }
@@ -68,9 +65,6 @@ const DoiMetadata: React.FunctionComponent<Props> = ({item}) => {
         <a target="_blank" rel="noreferrer" href={item.id}>
           {ReactHtmlParser(titleHtml)}
         </a>
-        {item.types.resourceTypeGeneral &&
-          <span className="small"> {startCase(item.types.resourceTypeGeneral)}</span>
-        }
       </h3>
     )
   }
@@ -127,6 +121,61 @@ const DoiMetadata: React.FunctionComponent<Props> = ({item}) => {
     return (
       <div className="description">
         {ReactHtmlParser(descriptionHtml)}
+      </div>
+    )
+  }
+
+  const registered = () => {
+    return (
+      <div className="registered">
+      DOI registered
+      {item.registered &&
+        <span> {new Date(item.registered).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}</span>
+      } via {item.registrationAgency.name}.
+      </div>
+    )
+  }
+
+  const tooltipResourceTypeGeneral = (
+    <Tooltip id="tooltipResourceTypeGeneral">
+      The general type of the content.
+    </Tooltip>
+  )
+
+  const tooltipFieldsOfScience = (
+    <Tooltip id="tooltipFieldsOfScience">
+      The OECD Fields of Science for the content.
+    </Tooltip>
+  )
+
+  const tooltipLanguage = (
+    <Tooltip id="tooltipLanguage">
+      The primary language of the content.
+    </Tooltip>
+  )
+
+  const tags = () => {
+    return (
+      <div className="tags">
+        {item.types.resourceTypeGeneral &&
+          <OverlayTrigger placement="top" overlay={tooltipResourceTypeGeneral}>
+            <Label bsStyle="info">{startCase(item.types.resourceTypeGeneral)}</Label>
+          </OverlayTrigger>
+        }
+        {item.fieldsOfScience &&
+          <span>
+            {item.fieldsOfScience.map(fos => (
+              <OverlayTrigger key={fos.id} placement="top" overlay={tooltipFieldsOfScience}>
+                <Label bsStyle="info">{fos.name}</Label>
+              </OverlayTrigger>
+            ))}
+          </span>
+        }
+        {item.language &&
+          <OverlayTrigger placement="top" overlay={tooltipLanguage}>
+            <Label bsStyle="info">{item.language.name}</Label>
+          </OverlayTrigger>
+        }
       </div>
     )
   }
@@ -190,6 +239,8 @@ const DoiMetadata: React.FunctionComponent<Props> = ({item}) => {
         {creators()}
         {metadata()}
         {description()}
+        {registered()}
+        {tags()}
         {metricsCounter()}
       </div>
         {links()}

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -36,6 +36,7 @@ interface ContentQueryData {
       pageInfo: PageInfo
       published: ContentFacet[]
       resourceTypes: ContentFacet[]
+      languages: ContentFacet[]
       fieldsOfScience: ContentFacet[]
       registrationAgencies: ContentFacet[]
       totalCount: Number
@@ -47,13 +48,14 @@ interface ContentQueryVar {
   cursor: string
   published: string
   resourceTypeId: string
+  language: string
   fieldOfScience: string
   registrationAgency: string
 }
 
 export const CONTENT_GQL = gql`
-  query getContentQuery($query: String, $cursor: String, $published: String, $resourceTypeId: String, $fieldOfScience: String, $registrationAgency: String) {
-    works(first: 25, query: $query, after: $cursor, published: $published, resourceTypeId: $resourceTypeId, fieldOfScience: $fieldOfScience, registrationAgency: $registrationAgency) {
+  query getContentQuery($query: String, $cursor: String, $published: String, $resourceTypeId: String, $language: String, $fieldOfScience: String, $registrationAgency: String) {
+    works(first: 25, query: $query, after: $cursor, published: $published, resourceTypeId: $resourceTypeId, language: $language, fieldOfScience: $fieldOfScience, registrationAgency: $registrationAgency) {
       totalCount
       pageInfo {
         endCursor
@@ -65,6 +67,11 @@ export const CONTENT_GQL = gql`
         count
       }
       published {
+        id
+        title
+        count
+      }
+      languages {
         id
         title
         count
@@ -102,7 +109,19 @@ export const CONTENT_GQL = gql`
         publicationYear
         publisher
         version
-        registrationAgency
+        fieldsOfScience {
+          id
+          name
+        }
+        language {
+          id
+          name
+        }
+        registrationAgency {
+          id
+          name
+        }
+        registered
         citationCount
         viewCount
         downloadCount
@@ -111,13 +130,14 @@ export const CONTENT_GQL = gql`
   }
 `
 
-export const Search: React.FunctionComponent = () => {
+const Search: React.FunctionComponent = () => {
   const router = useRouter()
   const [searchQuery, setSearchQuery] = useQueryState("query", { history: 'push' })
   /* eslint-disable no-unused-vars */
   const [published, setPublished] = useQueryState('published', { history: 'push' })
   const [resourceType, setResourceType] = useQueryState('resource-type', { history: 'push' })
-  const [fieldOfScience, setfieldOfScience] = useQueryState('field-of-science', { history: 'push' })
+  const [language, setLanguage] = useQueryState('language', { history: 'push' })
+  const [fieldOfScience, setFieldOfScience] = useQueryState('field-of-science', { history: 'push' })
   const [registrationAgency, setRegistrationAgency] = useQueryState('registration-agency', { history: 'push' })
   const [cursor, setCursor] = useQueryState('cursor', { history: 'push' })
   /* eslint-enable no-unused-vars */
@@ -126,7 +146,7 @@ export const Search: React.FunctionComponent = () => {
     CONTENT_GQL,
     {
       errorPolicy: 'all',
-      variables: { query: searchQuery, cursor: cursor, published: published as string, resourceTypeId: resourceType as string, fieldOfScience: fieldOfScience as string, registrationAgency: registrationAgency as string }
+      variables: { query: searchQuery, cursor: cursor, published: published as string, resourceTypeId: resourceType as string, language: language as string, fieldOfScience: fieldOfScience as string, registrationAgency: registrationAgency as string }
     }
   )
 
@@ -135,6 +155,7 @@ export const Search: React.FunctionComponent = () => {
   }
 
   const onSearchClear = () => {
+    setFieldOfScience(null)
     setSearchQuery('')
   }
 
@@ -178,7 +199,7 @@ export const Search: React.FunctionComponent = () => {
 
   React.useEffect(() => {
     const typingDelay = setTimeout(() => {
-      refetch({ query: searchQuery, cursor: cursor, published: published as string, resourceTypeId: resourceType as string, fieldOfScience: fieldOfScience as string, registrationAgency: registrationAgency as string })
+      refetch({ query: searchQuery, cursor: cursor, published: published as string, resourceTypeId: resourceType as string, language: language as string, fieldOfScience: fieldOfScience as string, registrationAgency: registrationAgency as string })
     }, 1000)
 
     let results: ContentNode[] = []
@@ -334,6 +355,24 @@ export const Search: React.FunctionComponent = () => {
                 {data.works.fieldsOfScience.map(facet => (
                   <li key={facet.id}>
                     {facetLink('field-of-science', facet.id)}
+                    <div className="facet-title">{facet.title}</div>
+                    <span className="number pull-right">{facet.count.toLocaleString('en-US')}</span>
+                    <div className="clearfix"/>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        }
+
+        {data.works.languages.length > 0 &&
+          <div className="panel facets add">
+            <div className="panel-body">
+              <h4>Language</h4>
+              <ul>
+                {data.works.languages.map(facet => (
+                  <li key={facet.id}>
+                    {facetLink('language', facet.id)}
                     <div className="facet-title">{facet.title}</div>
                     <span className="number pull-right">{facet.count.toLocaleString('en-US')}</span>
                     <div className="clearfix"/>

--- a/src/styles.css
+++ b/src/styles.css
@@ -115,3 +115,16 @@ input[type=text] {
 .work span.small {
   color: #88939a;
 }
+
+.tags .label {
+  margin-top: 2px;
+  margin-right: 3px;
+  font-size: 16px;
+}
+
+.tags .label-info {
+  background: #ffffff;
+  color: #2b84d2;
+  border: 2px solid #2b84d2;
+  cursor: pointer;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5632,7 +5632,7 @@ cypress@*:
     url "0.11.0"
     yauzl "2.10.0"
 
-cypress@4.9.0:
+cypress@^4.9.0:
   version "4.9.0"
   resolved "https://registry.yarnpkg.com/cypress/-/cypress-4.9.0.tgz#c188a3864ddf841c0fdc81a9e4eff5cf539cd1c1"
   integrity sha512-qGxT5E0j21FPryzhb0OBjCdhoR/n1jXtumpFFSBPYWsaZZhNaBvc3XlBUDEZKkkXPsqUFYiyhWdHN/zo0t5FcA==


### PR DESCRIPTION
## Purpose
Display language facet. Also display tags for language, resourceTypeGeneral, and field of science.

## Approach
Implement language facet the same way as the other facets. Also adding tags using the `label` bootstrap style.

<img width="1414" alt="Bildschirmfoto 2020-07-05 um 17 04 44" src="https://user-images.githubusercontent.com/23151/86535583-a7c75900-bee1-11ea-8f5c-c7e49c2fb163.png">


