### PR TITLE
Feature: types chart

### DIFF
--- a/src/components/TypesChart/TypesChart.test.tsx
+++ b/src/components/TypesChart/TypesChart.test.tsx
@@ -1,0 +1,64 @@
+/// <reference types="cypress" />
+
+import React from 'react'
+import {
+  mount
+} from 'cypress-react-unit-test'
+import TypesChart from './TypesChart'
+
+const data = {
+  "id": "https://orcid.org/0000-0003-1419-2405",
+  "name": "Martin Fenner",
+  "givenName": "Martin",
+  "familyName": "Fenner",
+  "citationCount": 0,
+  "viewCount": 0,
+  "downloadCount": 0,
+  "affiliation": [],
+  "works": {
+    "totalCount": 173,
+    "resourceTypes": [{
+        "title": "Text",
+        "count": 126
+      },
+      {
+        "title": "Audiovisual",
+        "count": 16
+      },
+      {
+        "title": "Dataset",
+        "count": 15
+      },
+      {
+        "title": "Software",
+        "count": 11
+      },
+      {
+        "title": "Collection",
+        "count": 3
+      },
+      {
+        "title": "Image",
+        "count": 2
+      }
+    ],
+  }
+}
+
+
+
+describe('TypesChart Component', () => {
+  it('normal data', () => {
+    mount(
+    <TypesChart data={ data.works.resourceTypes } />)
+      cy.get('.mark-arc > path')
+      .should('be.visible')
+      .should('have.length', 6)
+
+      cy.get('.mark-symbol > path')
+      .should('be.visible')
+      .should('have.length', 6)
+
+  })
+})
+      

--- a/src/components/TypesChart/TypesChart.test.tsx
+++ b/src/components/TypesChart/TypesChart.test.tsx
@@ -50,7 +50,7 @@ const data = {
 describe('TypesChart Component', () => {
   it('normal data', () => {
     mount(
-    <TypesChart data={ data.works.resourceTypes } />)
+    <TypesChart data={ data.works.resourceTypes } legend={true} />)
       cy.get('.mark-arc > path')
       .should('be.visible')
       .should('have.length', 6)
@@ -58,6 +58,19 @@ describe('TypesChart Component', () => {
       cy.get('.mark-symbol > path')
       .should('be.visible')
       .should('have.length', 6)
+
+  })
+
+  it('no legend', () => {
+    mount(
+    <TypesChart data={ data.works.resourceTypes } legend={false} />)
+      cy.get('.mark-arc > path')
+      .should('be.visible')
+      .should('have.length', 6)
+
+      cy.get('.mark-symbol > path')
+      .should('not.be.visible')
+      .should('have.length', 0)
 
   })
 })

--- a/src/components/TypesChart/TypesChart.test.tsx
+++ b/src/components/TypesChart/TypesChart.test.tsx
@@ -50,10 +50,14 @@ const data = {
 describe('TypesChart Component', () => {
   it('normal data', () => {
     mount(
-    <TypesChart data={ data.works.resourceTypes } legend={true} />)
+    <TypesChart data={ data.works.resourceTypes } count="173" legend={true} />)
       cy.get('.mark-arc > path')
       .should('be.visible')
       .should('have.length', 6)
+
+      cy.get('.mark-text > text')
+      .should('be.visible')
+      .contains('173')
 
       cy.get('.mark-symbol > path')
       .should('be.visible')
@@ -63,10 +67,14 @@ describe('TypesChart Component', () => {
 
   it('no legend', () => {
     mount(
-    <TypesChart data={ data.works.resourceTypes } legend={false} />)
+    <TypesChart data={ data.works.resourceTypes } count="1730" legend={false} />)
       cy.get('.mark-arc > path')
       .should('be.visible')
       .should('have.length', 6)
+
+      cy.get('.mark-text > text')
+      .should('be.visible')
+      .contains('1.7K')
 
       cy.get('.mark-symbol > path')
       .should('not.be.visible')

--- a/src/components/TypesChart/TypesChart.tsx
+++ b/src/components/TypesChart/TypesChart.tsx
@@ -3,10 +3,12 @@ import { VegaLite } from 'react-vega';
 import { Grid, Row } from 'react-bootstrap';
   /* eslint-disable no-unused-vars */
 import { VisualizationSpec } from 'vega-embed';
+import { compactNumbers } from '../../utils/helpers'
 
 type Props = {
   data?: [],
   doi?: string,
+  count?: string,
   legend?: any,
 }
 
@@ -18,7 +20,7 @@ const actions = {
 }
 
 /* eslint-disable no-unused-vars */
-const TypesChart: React.FunctionComponent<Props> = ({data, doi, legend}) => {
+const TypesChart: React.FunctionComponent<Props> = ({data, doi, count, legend}) => {
 
   const spec: VisualizationSpec = {
       "$schema": "https://vega.github.io/schema/vega-lite/v4.json",
@@ -26,28 +28,38 @@ const TypesChart: React.FunctionComponent<Props> = ({data, doi, legend}) => {
       "data": {
         "name": "table"
       },
-      "mark": {
-        "type": "arc",
-        "innerRadius": 70,
-        "cursor": "pointer",
-        "tooltip": true
-      },
-      "encoding": {
-        "theta": {
-          "field": "count",
-          "type": "quantitative",
-          "sort": "descending"
+      "layer": [
+        {
+        "mark": {
+          "type": "arc",
+          "innerRadius": 70,
+          "cursor": "pointer",
+          "tooltip": true
         },
-        "color": {
-          "field": "title",
-          "title": "Type",
-          "type": "nominal",
-          "legend": legend,
-          "scale": {
-            "scheme": "viridis"
+        "encoding": {
+          "theta": {
+            "field": "count",
+            "type": "quantitative",
+            "sort": "descending"
+          },
+          "color": {
+            "field": "title",
+            "title": "Type",
+            "type": "nominal",
+            "legend": legend,
+            "scale": {
+              "scheme": "viridis"
+            }
           }
+        },
+       },
+       {
+        "mark": {"type": "text", "fill": "#767676", "align": "center", "baseline": "middle", "fontSize": "36"},
+        "encoding": {
+          "text": {"value": compactNumbers(count)}
         }
       },
+      ],
       "view": {
         "stroke": null
       }

--- a/src/components/TypesChart/TypesChart.tsx
+++ b/src/components/TypesChart/TypesChart.tsx
@@ -7,6 +7,7 @@ import { VisualizationSpec } from 'vega-embed';
 type Props = {
   data?: [],
   doi?: string,
+  legend?: any,
 }
 
 const actions = {
@@ -17,7 +18,7 @@ const actions = {
 }
 
 /* eslint-disable no-unused-vars */
-const TypesChart: React.FunctionComponent<Props> = ({data, doi}) => {
+const TypesChart: React.FunctionComponent<Props> = ({data, doi, legend}) => {
 
   const spec: VisualizationSpec = {
       "$schema": "https://vega.github.io/schema/vega-lite/v4.json",
@@ -41,6 +42,7 @@ const TypesChart: React.FunctionComponent<Props> = ({data, doi}) => {
           "field": "title",
           "title": "Type",
           "type": "nominal",
+          "legend": legend,
           "scale": {
             "scheme": "viridis"
           }

--- a/src/components/TypesChart/TypesChart.tsx
+++ b/src/components/TypesChart/TypesChart.tsx
@@ -54,7 +54,7 @@ const TypesChart: React.FunctionComponent<Props> = ({data, doi, count, legend}) 
         },
        },
        {
-        "mark": {"type": "text", "fill": "#767676", "align": "center", "baseline": "middle", "fontSize": "36"},
+        "mark": {"type": "text", "fill": "#767676", "align": "center", "baseline": "middle", "fontSize": 36},
         "encoding": {
           "text": {"value": compactNumbers(count)}
         }

--- a/src/components/TypesChart/TypesChart.tsx
+++ b/src/components/TypesChart/TypesChart.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { VegaLite } from 'react-vega';
+import { Grid, Row } from 'react-bootstrap';
+  /* eslint-disable no-unused-vars */
+import { VisualizationSpec } from 'vega-embed';
+
+type Props = {
+  data?: [],
+  doi?: string,
+}
+
+const actions = {
+  export: true,
+  source: false,
+  compiled: false, 
+  editor: false,
+}
+
+/* eslint-disable no-unused-vars */
+const TypesChart: React.FunctionComponent<Props> = ({data, doi}) => {
+
+  const spec: VisualizationSpec = {
+      "$schema": "https://vega.github.io/schema/vega-lite/v4.json",
+      "description": "A simple donut chart with embedded data.",
+      "data": {
+        "name": "table"
+      },
+      "mark": {
+        "type": "arc",
+        "innerRadius": 70,
+        "cursor": "pointer",
+        "tooltip": true
+      },
+      "encoding": {
+        "theta": {
+          "field": "count",
+          "type": "quantitative",
+          "sort": "descending"
+        },
+        "color": {
+          "field": "title",
+          "title": "Type",
+          "type": "nominal",
+          "scale": {
+            "scheme": "viridis"
+          }
+        }
+      },
+      "view": {
+        "stroke": null
+      }
+  }
+
+
+  return (
+      <div className="panel panel-transparent">
+       <div className="citation-chart panel-body"> 
+       <Grid>
+        <Row>       
+          <VegaLite renderer="svg" spec={spec} data={{table: data}} actions={actions} />
+        </Row>
+       </Grid>
+       </div>
+      </div>
+   );
+}
+
+export default TypesChart


### PR DESCRIPTION
## Purpose

Component to create donut chart for resource type based on graphql response. 

- includes tootips and legend for the types

![visualization (8)](https://user-images.githubusercontent.com/1092861/86558502-ca955400-bf59-11ea-887e-0729b329cc78.png)


addresses: https://github.com/datacite/akita/issues/39


To review this PR, please:

	1. pull the PR and run the code locally
	2. run **yarn run cypress open** to see the visualisation 

Thanks

## Approach
<!--- _How does this change address the problem?_ -->

#### Open Questions and Pre-Merge TODOs
- Adding it into the person and organisation pages will be addresses is respective PRs
- We might consider to change the color palette in the future.

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve  -->

## Status
- [x] Ready for Review

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

