### PR TITLE
Add organisations search and display

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,6 +32,12 @@ module.exports = {
     ],
     "rules": {
         "react/react-in-jsx-scope": "warn",
-        "react/prop-types": "off"
+        "react/prop-types": "off",
+        "@typescript-eslint/no-unused-vars": [
+            1,
+            {
+                "args": "none"
+            }
+        ]
     }
 };

--- a/src/components/FilterItem/FilterItem.tsx
+++ b/src/components/FilterItem/FilterItem.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+import { useQueryState } from 'next-usequerystate'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faSquare, faCheckSquare } from '@fortawesome/free-regular-svg-icons'
+
+type Props = {
+    name: string
+    id: string
+    title: string
+    count: number
+}
+
+const FilterItem: React.FunctionComponent<Props> = ({ name, id, title, count }) => {
+    const [activeFilter, setActiveFilter] = useQueryState<string>(name);
+
+    const activeIcon = (id: string) => {
+        let icon = faSquare
+        if (id == activeFilter) {
+            icon = faCheckSquare
+        }
+
+        return (
+            <FontAwesomeIcon icon={icon} />
+        );
+    }
+
+    const toggleFilter = (id: string) => {
+        if (activeFilter !== id) {
+            setActiveFilter(id);
+        } else {
+            setActiveFilter(null);
+        }
+    };
+
+    return (
+        <div>
+            <a onClick={() => toggleFilter(id)}>{activeIcon(id)}</a>
+            <div className="facet-title">{title}</div>
+            <span className="number pull-right">{count.toLocaleString('en-US')}</span>
+            <div className="clearfix" />
+        </div>
+    )
+}
+
+export default FilterItem

--- a/src/components/Organization/Organization.tsx
+++ b/src/components/Organization/Organization.tsx
@@ -26,7 +26,7 @@ export const Organization: React.FunctionComponent<Props> = ({ organization, det
     const titleLink = () => {
         if (!detailPage) {
             return (
-                <Link href="/organizations/[organization]" as={`/organizations${encodeURIComponent(rorFromUrl(organization.id))}`}>
+                <Link href="/organization/[organization]" as={`/organizations${encodeURIComponent(rorFromUrl(organization.id))}`}>
                     <a>{organization.name}</a>
                 </Link>
             )

--- a/src/components/Organization/Organization.tsx
+++ b/src/components/Organization/Organization.tsx
@@ -5,26 +5,26 @@ import { rorFromUrl } from '../../utils/helpers'
 export interface OrganizationRecord {
     id: string;
     name: string;
-    type: string;
+    alternateNames: string[];
     url: string;
-    identifiers: [{
+    countryName: string;
+    identifiers: {
         identifier: string,
         identifierType: string
-    }];
+    }[];
 }
 
 type Props = {
     organization: OrganizationRecord;
-    linkToDetailPage: boolean;
+    detailPage: boolean;
 };
 
 
-export const Organization: React.FunctionComponent<Props> = ({ organization, linkToDetailPage }) => {
+export const Organization: React.FunctionComponent<Props> = ({ organization, detailPage }) => {
 
 
     const titleLink = () => {
-        console.log(linkToDetailPage);
-        if (linkToDetailPage) {
+        if (!detailPage) {
             return (
                 <Link href="/organizations/[organization]" as={`/organizations${encodeURIComponent(rorFromUrl(organization.id))}`}>
                     <a>{organization.name}</a>
@@ -45,9 +45,20 @@ export const Organization: React.FunctionComponent<Props> = ({ organization, lin
             <div className="panel-body">
                 <h3 className="work">
                     {titleLink()}
+                    {organization.alternateNames.length > 0 &&
+                        <small> ({organization.alternateNames.join(", ")})</small>
+                    }
                 </h3>
-                <p>Website: {organization.url}</p>
-                <p>Type: {organization.type}</p>
+                <p>Website: <a href={organization.url}>{organization.url}</a></p>
+                <p>Country: {organization.countryName}</p>
+                <h4>Other Identifiers</h4>
+                {organization.identifiers.length > 0 &&
+                    <ul className="ror-identifiers">
+                        {organization.identifiers.map(identifier => (
+                            <li key={identifier.identifier}><strong>{identifier.identifierType}</strong>: {identifier.identifier}</li>
+                        ))}
+                    </ul>
+                }
             </div>
         </div>
     )

--- a/src/components/Organization/Organization.tsx
+++ b/src/components/Organization/Organization.tsx
@@ -1,17 +1,8 @@
 import React from 'react';
-import Link from 'next/link'
-import { rorFromUrl } from '../../utils/helpers'
+import { OrganizationMetadata, OrganizationMetadataRecord } from '../OrganizationMetadata/OrganizationMetadata';
 
 export interface OrganizationRecord {
-    id: string;
-    name: string;
-    alternateNames: string[];
-    url: string;
-    countryName: string;
-    identifiers: {
-        identifier: string,
-        identifierType: string
-    }[];
+    metadata: OrganizationMetadataRecord;
 }
 
 type Props = {
@@ -22,44 +13,7 @@ type Props = {
 
 export const Organization: React.FunctionComponent<Props> = ({ organization, detailPage }) => {
 
-
-    const titleLink = () => {
-        if (!detailPage) {
-            return (
-                <Link href="/organization/[organization]" as={`/organizations${encodeURIComponent(rorFromUrl(organization.id))}`}>
-                    <a>{organization.name}</a>
-                </Link>
-            )
-        } else {
-            return (
-                <a target="_blank" rel="noreferrer" href={organization.id}>
-                    {organization.name}
-                </a>
-            )
-        }
-    }
-
-
     return (
-        <div key={organization.id} className="panel panel-transparent content-item">
-            <div className="panel-body">
-                <h3 className="work">
-                    {titleLink()}
-                    {organization.alternateNames.length > 0 &&
-                        <small> ({organization.alternateNames.join(", ")})</small>
-                    }
-                </h3>
-                <p>Website: <a href={organization.url}>{organization.url}</a></p>
-                <p>Country: {organization.countryName}</p>
-                <h4>Other Identifiers</h4>
-                {organization.identifiers.length > 0 &&
-                    <ul className="ror-identifiers">
-                        {organization.identifiers.map(identifier => (
-                            <li key={identifier.identifier}><strong>{identifier.identifierType}</strong>: {identifier.identifier}</li>
-                        ))}
-                    </ul>
-                }
-            </div>
-        </div>
+        <OrganizationMetadata metadata={organization.metadata} linkToExternal={detailPage}></OrganizationMetadata>
     )
 }

--- a/src/components/Organization/Organization.tsx
+++ b/src/components/Organization/Organization.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+export interface OrganizationRecord {
+    id: string;
+    name: string;
+}
+
+type Props = {
+    organization: OrganizationRecord;
+};
+
+
+export const Organization: React.FunctionComponent<Props> = ({ organization }) => {
+    return (
+        <div key={organization.id} className="panel panel-transparent content-item">
+            <div className="panel-body">
+                {organization.name}
+            </div>
+        </div>
+    )
+}

--- a/src/components/Organization/Organization.tsx
+++ b/src/components/Organization/Organization.tsx
@@ -15,16 +15,16 @@ export interface OrganizationRecord {
 
 type Props = {
     organization: OrganizationRecord;
-    linksToDetailpage: boolean;
+    linkToDetailPage: boolean;
 };
 
 
-export const Organization: React.FunctionComponent<Props> = ({ organization, linksToDetailpage }) => {
+export const Organization: React.FunctionComponent<Props> = ({ organization, linkToDetailPage }) => {
 
 
     const titleLink = () => {
-        console.log(linksToDetailpage);
-        if (linksToDetailpage) {
+        console.log(linkToDetailPage);
+        if (linkToDetailPage) {
             return (
                 <Link href="/organizations/[organization]" as={`/organizations${encodeURIComponent(rorFromUrl(organization.id))}`}>
                     <a>{organization.name}</a>

--- a/src/components/Organization/Organization.tsx
+++ b/src/components/Organization/Organization.tsx
@@ -7,13 +7,12 @@ export interface OrganizationRecord {
 
 type Props = {
     organization: OrganizationRecord;
-    detailPage: boolean;
 };
 
 
-export const Organization: React.FunctionComponent<Props> = ({ organization, detailPage }) => {
+export const Organization: React.FunctionComponent<Props> = ({ organization }) => {
 
     return (
-        <OrganizationMetadata metadata={organization.metadata} linkToExternal={detailPage}></OrganizationMetadata>
+        <OrganizationMetadata metadata={organization.metadata} linkToExternal={true}></OrganizationMetadata>
     )
 }

--- a/src/components/Organization/Organization.tsx
+++ b/src/components/Organization/Organization.tsx
@@ -1,20 +1,53 @@
 import React from 'react';
+import Link from 'next/link'
+import { rorFromUrl } from '../../utils/helpers'
 
 export interface OrganizationRecord {
     id: string;
     name: string;
+    type: string;
+    url: string;
+    identifiers: [{
+        identifier: string,
+        identifierType: string
+    }];
 }
 
 type Props = {
     organization: OrganizationRecord;
+    linksToDetailpage: boolean;
 };
 
 
-export const Organization: React.FunctionComponent<Props> = ({ organization }) => {
+export const Organization: React.FunctionComponent<Props> = ({ organization, linksToDetailpage }) => {
+
+
+    const titleLink = () => {
+        console.log(linksToDetailpage);
+        if (linksToDetailpage) {
+            return (
+                <Link href="/organizations/[organization]" as={`/organizations${encodeURIComponent(rorFromUrl(organization.id))}`}>
+                    <a>{organization.name}</a>
+                </Link>
+            )
+        } else {
+            return (
+                <a target="_blank" rel="noreferrer" href={organization.id}>
+                    {organization.name}
+                </a>
+            )
+        }
+    }
+
+
     return (
         <div key={organization.id} className="panel panel-transparent content-item">
             <div className="panel-body">
-                {organization.name}
+                <h3 className="work">
+                    {titleLink()}
+                </h3>
+                <p>Website: {organization.url}</p>
+                <p>Type: {organization.type}</p>
             </div>
         </div>
     )

--- a/src/components/OrganizationContainer/OrganizationContainer.tsx
+++ b/src/components/OrganizationContainer/OrganizationContainer.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react'
 import { gql, useQuery } from '@apollo/client'
-import { Row, Col } from 'react-bootstrap'
+import { Row } from 'react-bootstrap'
 
 import Error from "../Error/Error"
 import { Organization, OrganizationRecord } from '../Organization/Organization';
+import { OrganizationMetadataRecord } from '../OrganizationMetadata/OrganizationMetadata';
 
 type Props = {
     rorId: string;
@@ -73,7 +74,7 @@ const OrganizationContainer: React.FunctionComponent<Props> = ({ rorId }) => {
                 return i.identifier != "";
             });
 
-            let org: OrganizationRecord = {
+            let orgMetadata: OrganizationMetadataRecord = {
                 id: organization.id,
                 name: organization.name,
                 alternateNames: organization.alternateName,
@@ -82,7 +83,9 @@ const OrganizationContainer: React.FunctionComponent<Props> = ({ rorId }) => {
                 identifiers: identifiers,
             };
 
-            setOrganization(org);
+            setOrganization({
+                metadata: orgMetadata
+            });
         }
 
     }, [data]);

--- a/src/components/OrganizationContainer/OrganizationContainer.tsx
+++ b/src/components/OrganizationContainer/OrganizationContainer.tsx
@@ -190,20 +190,6 @@ const OrganizationContainer: React.FunctionComponent<Props> = ({ rorId }) => {
     }
 
     const relatedContent = () => {
-        if (!data.organization.works.totalCount) return (
-            <div className="panel panel-transparent">
-                <div className="panel-body">
-                    <h3 className="member">Introduction</h3>
-                    <p>DataCite Commons is a web interface where you can explore the complete
-                    collection of publicly available DOIs from DOI registation agencies DataCite
-              and Crossref. You can search, filter, cite results, and more!</p>
-                    <p>DataCite Commons is work in progress and will officially launch in October 2020.</p>
-                    <p><a href="https://portal.productboard.com/71qotggkmbccdwzokuudjcsb/c/35-common-doi-search" target="_blank" rel="noreferrer">Provide input to the DataCite Roadmap</a> | <a href="https://support.datacite.org/docs/datacite-search-user-documentation" target="_blank" rel="noreferrer">Information in DataCite Support</a></p>
-                </div>
-            </div>
-        )
-
-
         const hasNextPage = data.organization.works.pageInfo ? data.organization.works.pageInfo.hasNextPage : false
         const endCursor = data.organization.works.pageInfo ? data.organization.works.pageInfo.endCursor : ""
 

--- a/src/components/OrganizationContainer/OrganizationContainer.tsx
+++ b/src/components/OrganizationContainer/OrganizationContainer.tsx
@@ -1,0 +1,120 @@
+import * as React from 'react'
+import { gql, useQuery } from '@apollo/client'
+import { Row, Col } from 'react-bootstrap'
+
+import Error from "../Error/Error"
+import { Organization, OrganizationRecord } from '../Organization/Organization';
+
+type Props = {
+    rorId: string;
+};
+
+interface OrganizationResult {
+    id: string;
+    name: string;
+    alternateName: string[];
+    url: string;
+    address: {
+        country: string
+    }
+    identifiers: [{
+        identifier: string,
+        identifierType: string
+    }];
+}
+
+interface OrganizationQueryData {
+    organization: OrganizationResult
+}
+
+interface OrganizationQueryVar {
+    id: string;
+}
+
+export const ORGANIZATION_GQL = gql`
+query getOrganizationQuery($id: ID!) {
+    organization(id: $id) {
+        id,
+        name,
+        alternateName,
+        url,
+        address {
+        country
+        },
+        identifiers {
+        identifier,
+        identifierType
+        }
+    }
+}
+`;
+
+
+const OrganizationContainer: React.FunctionComponent<Props> = ({ rorId }) => {
+    const [organization, setOrganization] = React.useState<OrganizationRecord>();
+
+    const fullId = "https://ror.org/" + rorId;
+
+    const { loading, error, data } = useQuery<OrganizationQueryData, OrganizationQueryVar>(
+        ORGANIZATION_GQL,
+        {
+            errorPolicy: 'all',
+            variables: {
+                id: fullId
+            }
+        })
+
+
+    React.useEffect(() => {
+
+        if (data) {
+            let organization = data.organization;
+            let identifiers = organization.identifiers.filter(i => {
+                return i.identifier != "";
+            });
+
+            let org: OrganizationRecord = {
+                id: organization.id,
+                name: organization.name,
+                alternateNames: organization.alternateName,
+                url: organization.url,
+                countryName: organization.address.country,
+                identifiers: identifiers,
+            };
+
+            setOrganization(org);
+        }
+
+    }, [data]);
+
+    if (loading) return <p>Loading...</p>;
+
+    if (error) {
+        return <Error title="No Service" message="Unable to retrieve organization" />
+    }
+
+    if (!organization) {
+        return <Error title="No Data" message="No organization data" />
+    }
+
+    const content = () => {
+        return (
+            <div className="col-md-9 panel-list" id="content">
+                <div className="panel panel-transparent content-item">
+                    <div className="panel-body">
+                        <Organization organization={organization} detailPage={true}></Organization>
+                    </div>
+                    <br />
+                </div>
+            </div>
+        )
+    }
+
+    return (
+        <Row>
+            {content()}
+        </Row>
+    )
+}
+
+export default OrganizationContainer

--- a/src/components/OrganizationMetadata/OrganizationMetadata.tsx
+++ b/src/components/OrganizationMetadata/OrganizationMetadata.tsx
@@ -25,7 +25,7 @@ export const OrganizationMetadata: React.FunctionComponent<Props> = ({ metadata,
     const titleLink = () => {
         if (!linkToExternal) {
             return (
-                <Link href="/organization/[...organization]" as={`/organization${rorFromUrl(metadata.id)}`}>
+                <Link href="/organization/[organization]" as={`/organization${rorFromUrl(metadata.id)}`}>
                     <a>{metadata.name}</a>
                 </Link>
             )

--- a/src/components/OrganizationMetadata/OrganizationMetadata.tsx
+++ b/src/components/OrganizationMetadata/OrganizationMetadata.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import Link from 'next/link'
+import { rorFromUrl } from '../../utils/helpers'
+
+export interface OrganizationMetadataRecord {
+    id: string;
+    name: string;
+    alternateNames: string[];
+    url: string;
+    countryName: string;
+    identifiers: {
+        identifier: string,
+        identifierType: string
+    }[];
+}
+
+type Props = {
+    metadata: OrganizationMetadataRecord;
+    linkToExternal: boolean;
+};
+
+
+export const OrganizationMetadata: React.FunctionComponent<Props> = ({ metadata, linkToExternal }) => {
+
+    const titleLink = () => {
+        if (!linkToExternal) {
+            return (
+                <Link href="/organization/[...organization]" as={`/organization${rorFromUrl(metadata.id)}`}>
+                    <a>{metadata.name}</a>
+                </Link>
+            )
+        } else {
+            return (
+                <a target="_blank" rel="noreferrer" href={metadata.id}>
+                    {metadata.name}
+                </a>
+            )
+        }
+    }
+
+    return (
+        <div key={metadata.id} className="panel panel-transparent content-item">
+            <div className="panel-body">
+                <h3 className="work">
+                    {titleLink()}
+                    {metadata.alternateNames.length > 0 &&
+                        <small> ({metadata.alternateNames.join(", ")})</small>
+                    }
+                </h3>
+                <p>Website: <a href={metadata.url}>{metadata.url}</a></p>
+                <p>Country: {metadata.countryName}</p>
+                <h4>Other Identifiers</h4>
+                {metadata.identifiers.length > 0 &&
+                    <ul className="ror-identifiers">
+                        {metadata.identifiers.map(identifier => (
+                            <li key={identifier.identifier}><strong>{identifier.identifierType}</strong>: {identifier.identifier}</li>
+                        ))}
+                    </ul>
+                }
+            </div>
+        </div>
+    )
+}
+
+export default OrganizationMetadata;

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -4,7 +4,7 @@ import { Row, Col } from 'react-bootstrap'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faSearch, faTimes } from '@fortawesome/free-solid-svg-icons'
 import SearchContent from '../SearchContent/SearchContent'
-// import SearchOrganization from '../SearchOrganization/SearchOrganization'
+import SearchOrganization from '../SearchOrganization/SearchOrganization'
 // import SearchPerson from '../SearchPerson/SearchPerson'
 
 const Search: React.FunctionComponent = () => {
@@ -54,11 +54,11 @@ const Search: React.FunctionComponent = () => {
       </Row>
       <Row>
         <Col>
-          {!searchQuery
+          {/* {!searchQuery
             ? renderIntroduction()
             : <SearchContent searchQuery={searchQuery} />
-          }
-          {/* <SearchOrganization searchQuery={searchQuery} /> */}
+          } */}
+          <SearchOrganization searchQuery={searchQuery} />
           {/* <SearchPerson searchQuery={searchQuery} /> */}
         </Col>
       </Row>

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -70,7 +70,7 @@ const Search: React.FunctionComponent = () => {
                 : (<SearchContent searchQuery={searchQuery} />)
               }
             </Tab>
-            <Tab eventKey="organisations" title="Organisations" disabled>
+            <Tab eventKey="organisations" title="Organisations">
               {!searchQuery || searchQuery === " "
                 ? (renderIntroduction())
                 : (<SearchOrganization searchQuery={searchQuery} />)

--- a/src/components/SearchOrganization/SearchOrganization.tsx
+++ b/src/components/SearchOrganization/SearchOrganization.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { gql, useQuery } from '@apollo/client'
-import { Row, Col } from 'react-bootstrap'
+import { Row, Alert } from 'react-bootstrap'
 
 import Error from "../Error/Error"
 import { Organization, OrganizationRecord } from '../Organization/Organization';
@@ -124,33 +124,57 @@ const SearchOrganizations: React.FunctionComponent<Props> = ({ searchQuery }) =>
   }, [searchQuery, data, refetch]);
 
   const renderResults = () => {
-    if (loading) return <p>Loading...</p>;
+
+    if (!loading && searchResults.length == 0) return (
+      <React.Fragment>
+        <Alert bsStyle="warning">
+          No content found.
+        </Alert>
+      </React.Fragment>
+    )
 
     if (error) return <Error title="Something went wrong." message="Unable to load services." />;
 
     if (!data) return '';
 
     return (
-      <div>
-        {searchResults.length > 1 &&
-          <h3 className="member-results">{data.organizations.totalCount.toLocaleString('en-US')} Results</h3>
-        }
+      <div className="col-md-9 panel-list" id="content">
+        <div className="panel panel-transparent content-item">
+          <div className="panel-body">
+            {searchResults.length > 1 &&
+              <h3 className="member-results">{data.organizations.totalCount.toLocaleString('en-US')} Results</h3>
+            }
 
-        <ul>
-          {searchResults.map(item => (
-            <React.Fragment key={item.metadata.id}>
-              <Organization organization={item} detailPage={false}></Organization>
-            </React.Fragment>
-          ))}
-        </ul>
+            <ul>
+              {searchResults.map(item => (
+                <React.Fragment key={item.metadata.id}>
+                  <Organization organization={item} detailPage={false}></Organization>
+                </React.Fragment>
+              ))}
+            </ul>
+          </div>
+        </div>
       </div>
     )
   }
 
+  const renderFacets = () => {
+
+    return (
+      <div className="col-md-3 hidden-xs hidden-sm">
+        <div className="panel panel-transparent">
+          <div className="panel-body">
+            <div className="edit">Filters</div>
+          </div>
+        </div>
+      </div>
+    )
+  }
 
   return (
     <Row>
-      <Col>{renderResults()}</Col>
+      {renderFacets()}
+      {renderResults()}
     </Row>
   )
 }

--- a/src/components/SearchOrganization/SearchOrganization.tsx
+++ b/src/components/SearchOrganization/SearchOrganization.tsx
@@ -46,7 +46,7 @@ interface OrganizationsQueryData {
 }
 
 export const ORGANIZATIONS_GQL = gql`
-  query getContentQuery(
+  query getOrganizationQuery(
     $query: String,
     $cursor: String,
     ) {

--- a/src/components/SearchOrganization/SearchOrganization.tsx
+++ b/src/components/SearchOrganization/SearchOrganization.tsx
@@ -125,7 +125,7 @@ const SearchOrganizations: React.FunctionComponent<Props> = ({ searchQuery }) =>
         <ul>
           {searchResults.map(item => (
             <React.Fragment key={item.id}>
-              <Organization organization={item} linksToDetailpage={true}></Organization>
+              <Organization organization={item} linkToDetailPage={true}></Organization>
             </React.Fragment>
           ))}
         </ul>

--- a/src/components/SearchOrganization/SearchOrganization.tsx
+++ b/src/components/SearchOrganization/SearchOrganization.tsx
@@ -174,7 +174,7 @@ const SearchOrganizations: React.FunctionComponent<Props> = ({ searchQuery }) =>
             <ul>
               {searchResults.map(item => (
                 <React.Fragment key={item.metadata.id}>
-                  <Organization organization={item} detailPage={false}></Organization>
+                  <Organization organization={item}></Organization>
                 </React.Fragment>
               ))}
             </ul>

--- a/src/components/SearchOrganization/SearchOrganization.tsx
+++ b/src/components/SearchOrganization/SearchOrganization.tsx
@@ -1,16 +1,140 @@
 import * as React from 'react'
-// import { gql } from '@apollo/client'
+import { gql, useQuery } from '@apollo/client'
 import { Row, Col } from 'react-bootstrap'
+
+import Error from "../Error/Error"
+import { Organization, OrganizationRecord } from '../Organization/Organization';
 
 type Props = {
   searchQuery: string;
 };
 
+interface PageInfo {
+  endCursor: string;
+  hasNextPage: boolean;
+}
+
+interface OrganizationsNode {
+  id: string;
+  name: string;
+  alternateName: string[];
+  type: string;
+  url: string;
+  identifiers: [{
+    identifier: string,
+    identifierType: string
+  }];
+}
+
+interface OrganizationsEdge {
+  node: OrganizationsNode
+}
+
+interface OrganizationsQueryVar {
+  query: string;
+  cursor: string;
+}
+
+interface OrganizationsQueryData {
+  organizations: {
+    totalCount: number;
+    pageInfo: PageInfo;
+    edges: OrganizationsEdge[];
+  },
+}
+
+export const ORGANIZATIONS_GQL = gql`
+  query getContentQuery(
+    $query: String,
+    $cursor: String,
+    ) {
+    organizations(query: $query, after: $cursor) {
+      totalCount
+      pageInfo {
+        endCursor
+        hasNextPage
+      }
+      edges {
+        node {
+          id,
+          name,
+          alternateName,
+          type,
+          url,
+          identifiers {
+            identifier,
+            identifierType
+          }
+        }
+      }
+    }
+  }
+`;
+
 const SearchOrganizations: React.FunctionComponent<Props> = ({ searchQuery }) => {
+  const [searchResults, setSearchResults] = React.useState<OrganizationRecord[]>([]);
+
+  const { loading, error, data, refetch } = useQuery<OrganizationsQueryData, OrganizationsQueryVar>(
+    ORGANIZATIONS_GQL,
+    {
+      errorPolicy: 'all',
+      variables: {
+        query: searchQuery, cursor: ''
+      }
+    })
+
+
+  React.useEffect(() => {
+    refetch({ query: searchQuery, cursor: '' });
+
+    const results: OrganizationRecord[] = [];
+
+    if (data) {
+      data.organizations.edges.map(edge => {
+        results.push(
+          {
+            id: edge.node.id,
+            name: edge.node.name,
+          }
+        );
+
+        return results;
+      })
+
+      setSearchResults(results);
+    }
+
+  }, [searchQuery, data, refetch]);
+
+
+  const renderResults = () => {
+    if (loading) return <p>Loading...</p>;
+
+    if (error) return <Error title="Something went wrong." message="Unable to load services." />;
+
+    if (!data) return '';
+
+    return (
+      <div>
+        {searchResults.length > 1 &&
+          <h3 className="member-results">{data.organizations.totalCount.toLocaleString('en-US')} Results</h3>
+        }
+
+        <ul>
+          {searchResults.map(item => (
+            <React.Fragment key={item.id}>
+              <Organization organization={item}></Organization>
+            </React.Fragment>
+          ))}
+        </ul>
+      </div>
+    )
+  }
+
 
   return (
     <Row>
-      <Col>{searchQuery}</Col>
+      <Col>{renderResults()}</Col>
     </Row>
   )
 }

--- a/src/components/SearchOrganization/SearchOrganization.tsx
+++ b/src/components/SearchOrganization/SearchOrganization.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react'
 import { gql, useQuery } from '@apollo/client'
 import { Row, Alert } from 'react-bootstrap'
-
+import { useQueryState } from 'next-usequerystate'
+import Pager from "../Pager/Pager"
 import Error from "../Error/Error"
 import { Organization, OrganizationRecord } from '../Organization/Organization';
 import { OrganizationMetadataRecord } from '../OrganizationMetadata/OrganizationMetadata';
@@ -77,6 +78,7 @@ export const ORGANIZATIONS_GQL = gql`
 `;
 
 const SearchOrganizations: React.FunctionComponent<Props> = ({ searchQuery }) => {
+  const [cursor] = useQueryState('cursor', { history: 'push' })
   const [searchResults, setSearchResults] = React.useState<OrganizationRecord[]>([]);
 
   const { loading, error, data, refetch } = useQuery<OrganizationsQueryData, OrganizationsQueryVar>(
@@ -84,13 +86,13 @@ const SearchOrganizations: React.FunctionComponent<Props> = ({ searchQuery }) =>
     {
       errorPolicy: 'all',
       variables: {
-        query: searchQuery, cursor: ''
+        query: searchQuery, cursor: cursor
       }
     })
 
 
   React.useEffect(() => {
-    refetch({ query: searchQuery, cursor: '' });
+    refetch({ query: searchQuery, cursor: cursor });
 
     const results: OrganizationRecord[] = [];
 
@@ -137,6 +139,9 @@ const SearchOrganizations: React.FunctionComponent<Props> = ({ searchQuery }) =>
 
     if (!data) return '';
 
+    const hasNextPage = data.organizations.pageInfo ? data.organizations.pageInfo.hasNextPage : false
+    const endCursor = data.organizations.pageInfo ? data.organizations.pageInfo.endCursor : ""
+
     return (
       <div className="col-md-9 panel-list" id="content">
         <div className="panel panel-transparent content-item">
@@ -152,6 +157,9 @@ const SearchOrganizations: React.FunctionComponent<Props> = ({ searchQuery }) =>
                 </React.Fragment>
               ))}
             </ul>
+
+            <Pager url={'/?'} hasNextPage={hasNextPage} endCursor={endCursor}></Pager>
+
           </div>
         </div>
       </div>

--- a/src/components/SearchOrganization/SearchOrganization.tsx
+++ b/src/components/SearchOrganization/SearchOrganization.tsx
@@ -5,8 +5,7 @@ import { useQueryState } from 'next-usequerystate'
 import Pager from "../Pager/Pager"
 import FilterItem from "../FilterItem/FilterItem"
 import Error from "../Error/Error"
-import { Organization, OrganizationRecord } from '../Organization/Organization';
-import { OrganizationMetadataRecord } from '../OrganizationMetadata/OrganizationMetadata';
+import { OrganizationMetadata, OrganizationMetadataRecord } from '../OrganizationMetadata/OrganizationMetadata';
 
 type Props = {
   searchQuery: string;
@@ -101,7 +100,7 @@ const SearchOrganizations: React.FunctionComponent<Props> = ({ searchQuery }) =>
   // TODO: Until API supports filter comment out for now as we dont use them.
   // const [orgType] = useQueryState<string>('orgtype');
   // const [orgCountry] = useQueryState<string>('orgcountry');
-  const [searchResults, setSearchResults] = React.useState<OrganizationRecord[]>([]);
+  const [searchResults, setSearchResults] = React.useState<OrganizationMetadataRecord[]>([]);
 
   const { loading, error, data, refetch } = useQuery<OrganizationsQueryData, OrganizationsQueryVar>(
     ORGANIZATIONS_GQL,
@@ -115,7 +114,7 @@ const SearchOrganizations: React.FunctionComponent<Props> = ({ searchQuery }) =>
   React.useEffect(() => {
     refetch({ query: searchQuery, cursor: cursor });
 
-    const results: OrganizationRecord[] = [];
+    const results: OrganizationMetadataRecord[] = [];
 
     if (data) {
 
@@ -134,9 +133,7 @@ const SearchOrganizations: React.FunctionComponent<Props> = ({ searchQuery }) =>
           identifiers: identifiers,
         };
 
-        results.push({
-          metadata: orgMetadata
-        });
+        results.push(orgMetadata);
 
         return results;
       })
@@ -173,8 +170,8 @@ const SearchOrganizations: React.FunctionComponent<Props> = ({ searchQuery }) =>
 
             <ul>
               {searchResults.map(item => (
-                <React.Fragment key={item.metadata.id}>
-                  <Organization organization={item}></Organization>
+                <React.Fragment key={item.id}>
+                  <OrganizationMetadata metadata={item} linkToExternal={false}></OrganizationMetadata>
                 </React.Fragment>
               ))}
             </ul>

--- a/src/components/SearchOrganization/SearchOrganization.tsx
+++ b/src/components/SearchOrganization/SearchOrganization.tsx
@@ -91,12 +91,15 @@ const SearchOrganizations: React.FunctionComponent<Props> = ({ searchQuery }) =>
 
     if (data) {
       data.organizations.edges.map(edge => {
-        results.push(
-          {
-            id: edge.node.id,
-            name: edge.node.name,
-          }
-        );
+        let org: OrganizationRecord = {
+          id: edge.node.id,
+          name: edge.node.name,
+          type: edge.node.type,
+          url: edge.node.url,
+          identifiers: edge.node.identifiers,
+        };
+
+        results.push(org);
 
         return results;
       })
@@ -105,7 +108,6 @@ const SearchOrganizations: React.FunctionComponent<Props> = ({ searchQuery }) =>
     }
 
   }, [searchQuery, data, refetch]);
-
 
   const renderResults = () => {
     if (loading) return <p>Loading...</p>;
@@ -123,7 +125,7 @@ const SearchOrganizations: React.FunctionComponent<Props> = ({ searchQuery }) =>
         <ul>
           {searchResults.map(item => (
             <React.Fragment key={item.id}>
-              <Organization organization={item}></Organization>
+              <Organization organization={item} linksToDetailpage={true}></Organization>
             </React.Fragment>
           ))}
         </ul>

--- a/src/components/SearchOrganization/SearchOrganization.tsx
+++ b/src/components/SearchOrganization/SearchOrganization.tsx
@@ -18,8 +18,10 @@ interface OrganizationsNode {
   id: string;
   name: string;
   alternateName: string[];
-  type: string;
   url: string;
+  address: {
+    country: string
+  }
   identifiers: [{
     identifier: string,
     identifierType: string
@@ -59,8 +61,10 @@ export const ORGANIZATIONS_GQL = gql`
           id,
           name,
           alternateName,
-          type,
           url,
+          address {
+            country
+          },
           identifiers {
             identifier,
             identifierType
@@ -90,13 +94,20 @@ const SearchOrganizations: React.FunctionComponent<Props> = ({ searchQuery }) =>
     const results: OrganizationRecord[] = [];
 
     if (data) {
+
       data.organizations.edges.map(edge => {
+        // Filter out any empty identifiers
+        let identifiers = edge.node.identifiers.filter(i => {
+          return i.identifier != "";
+        });
+
         let org: OrganizationRecord = {
           id: edge.node.id,
           name: edge.node.name,
-          type: edge.node.type,
+          alternateNames: edge.node.alternateName,
           url: edge.node.url,
-          identifiers: edge.node.identifiers,
+          countryName: edge.node.address.country,
+          identifiers: identifiers,
         };
 
         results.push(org);
@@ -125,7 +136,7 @@ const SearchOrganizations: React.FunctionComponent<Props> = ({ searchQuery }) =>
         <ul>
           {searchResults.map(item => (
             <React.Fragment key={item.id}>
-              <Organization organization={item} linkToDetailPage={true}></Organization>
+              <Organization organization={item} detailPage={false}></Organization>
             </React.Fragment>
           ))}
         </ul>

--- a/src/components/SearchOrganization/SearchOrganization.tsx
+++ b/src/components/SearchOrganization/SearchOrganization.tsx
@@ -4,6 +4,7 @@ import { Row, Col } from 'react-bootstrap'
 
 import Error from "../Error/Error"
 import { Organization, OrganizationRecord } from '../Organization/Organization';
+import { OrganizationMetadataRecord } from '../OrganizationMetadata/OrganizationMetadata';
 
 type Props = {
   searchQuery: string;
@@ -101,7 +102,7 @@ const SearchOrganizations: React.FunctionComponent<Props> = ({ searchQuery }) =>
           return i.identifier != "";
         });
 
-        let org: OrganizationRecord = {
+        let orgMetadata: OrganizationMetadataRecord = {
           id: edge.node.id,
           name: edge.node.name,
           alternateNames: edge.node.alternateName,
@@ -110,7 +111,9 @@ const SearchOrganizations: React.FunctionComponent<Props> = ({ searchQuery }) =>
           identifiers: identifiers,
         };
 
-        results.push(org);
+        results.push({
+          metadata: orgMetadata
+        });
 
         return results;
       })
@@ -135,7 +138,7 @@ const SearchOrganizations: React.FunctionComponent<Props> = ({ searchQuery }) =>
 
         <ul>
           {searchResults.map(item => (
-            <React.Fragment key={item.id}>
+            <React.Fragment key={item.metadata.id}>
               <Organization organization={item} detailPage={false}></Organization>
             </React.Fragment>
           ))}

--- a/src/pages/organization/[organization].tsx
+++ b/src/pages/organization/[organization].tsx
@@ -1,0 +1,22 @@
+import React from "react"
+import Layout from '../../components/Layout/Layout'
+import OrganizationContainer from '../../components/OrganizationContainer/OrganizationContainer'
+import { GetServerSideProps } from 'next'
+
+const OrganizationPage = ({ organizationPath }) => {
+    return (
+        <Layout title={process.env.NEXT_PUBLIC_TITLE}>
+            <OrganizationContainer rorId={organizationPath} />
+        </Layout>
+    )
+}
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+    const organizationPath = context.params.organization
+
+    return {
+        props: { organizationPath },
+    }
+}
+
+export default OrganizationPage

--- a/src/styles.css
+++ b/src/styles.css
@@ -107,14 +107,14 @@ ul.counter-list {
 }
 
 /* remove iOS input shadow, from https://stackoverflow.com/questions/23211656/remove-ios-input-shadow */
-input[type=text] {   
+input[type=text] {
   /* Remove First */
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
 
   /* Then Style */
-  border-radius: 5px;   
+  border-radius: 5px;
 }
 
 .work span.small {
@@ -145,3 +145,7 @@ input[type=text] {
   margin: 3px;
 }
 
+ul.ror-identifiers {
+  list-style: none;
+  padding: 0;
+}

--- a/src/utils/helpers.tsx
+++ b/src/utils/helpers.tsx
@@ -4,13 +4,23 @@ NumberFormat.__addLocaleData(
 );
 
 export const compactNumbers = (num) => {
-   if (num >= 1e3) return  toLocaleString(num, 'en', { notation: "compact" , compactDisplay: "short" })
-   return num
+  if (num >= 1e3) return toLocaleString(num, 'en', { notation: "compact", compactDisplay: "short" })
+  return num
 }
 
 
-export const orcidFromUrl = (orcidUrl :string) => {
+export const orcidFromUrl = (orcidUrl: string) => {
   const url = document.createElement('a');
   url.href = orcidUrl;
+  return url.pathname
+}
+
+export const rorFromUrl = (rorUrl: string) => {
+  if (!rorUrl) {
+    return null
+  }
+
+  const url = document.createElement('a');
+  url.href = rorUrl;
   return url.pathname
 }


### PR DESCRIPTION
## Purpose
This is to create new organisations search and organisations display.

## Approach
Added search inline with other existing searches

![image](https://user-images.githubusercontent.com/7294431/88920731-9fa6d300-d26d-11ea-8c40-08be9c12edf5.png)

Added organisation display with works display in line with other components:

![image](https://user-images.githubusercontent.com/7294431/88920798-ba794780-d26d-11ea-8069-bd9b9e34c968.png)

## To consider

At the moment I've kept the OrganizationContainer as the one that handles displaying related works as this is temporarily cleaner.
I'd like to actually move the related works into a seperate "Works" component that then renders the metadata, this could be used for the details pages of Person and Organization.

TODO

- [ ] Tests need adding #63
- [ ] API needs updating to support functional filtering see #62

## Learning
Considerations of how to handle components, ideally they should be isolated and only contain the data and types they need to function, especially when working with presentational components only.
