### PR TITLE
Visualize license information

### DIFF
--- a/cypress/fixtures/licenseChart.json
+++ b/cypress/fixtures/licenseChart.json
@@ -1,0 +1,23 @@
+{
+  "id": "https://orcid.org/0000-0003-1419-2405",
+  "name": "Martin Fenner",
+  "givenName": "Martin",
+  "familyName": "Fenner",
+  "citationCount": 0,
+  "viewCount": 0,
+  "downloadCount": 0,
+  "affiliation": [],
+  "works": {
+    "totalCount": 173,
+    "licenses": [
+      {
+        "title": "CC-BY-4.0",
+        "count": 126
+      },
+      {
+        "title": "CC0-1.0",
+        "count": 16
+      }
+    ]
+  }
+}

--- a/src/components/LicenseChart/LicenseChart.test.tsx
+++ b/src/components/LicenseChart/LicenseChart.test.tsx
@@ -1,0 +1,38 @@
+/// <reference types="cypress" />
+
+import React from 'react'
+import { mount } from 'cypress-react-unit-test'
+import LicenseChart from './LicenseChart'
+
+describe('LicenseChart Component', () => {
+  let data
+  beforeEach(function () {
+    cy.fixture('licenseChart.json').then((d) => {
+      data = d
+    })
+  })
+
+  it('normal data', () => {
+    mount(
+      <LicenseChart data={data.works.licenses} count={173} legend={true} />
+    )
+    cy.get('.mark-arc > path').should('be.visible').should('have.length', 2)
+
+    cy.get('.mark-text > text').should('be.visible').contains('173')
+
+    cy.get('.mark-symbol > path').should('be.visible').should('have.length', 2)
+  })
+
+  it('no legend', () => {
+    mount(
+      <LicenseChart data={data.works.licenses} count={1730} legend={false} />
+    )
+    cy.get('.mark-arc > path').should('be.visible').should('have.length', 2)
+
+    cy.get('.mark-text > text').should('be.visible').contains('1.7K')
+
+    cy.get('.mark-symbol > path')
+      .should('not.be.visible')
+      .should('have.length', 0)
+  })
+})

--- a/src/components/LicenseChart/LicenseChart.tsx
+++ b/src/components/LicenseChart/LicenseChart.tsx
@@ -80,7 +80,7 @@ const LicenseChart: React.FunctionComponent<Props> = ({
   const title = () => {
     return (
       <React.Fragment>
-        Distribution by license
+        <h4>Works by license</h4>
       </React.Fragment>
     )
   }

--- a/src/components/LicenseChart/LicenseChart.tsx
+++ b/src/components/LicenseChart/LicenseChart.tsx
@@ -21,7 +21,7 @@ const actions = {
   editor: false
 }
 
-const TypesChart: React.FunctionComponent<Props> = ({
+const LicenseChart: React.FunctionComponent<Props> = ({
   data,
   count,
   legend
@@ -31,7 +31,7 @@ const TypesChart: React.FunctionComponent<Props> = ({
     description: 'A simple donut chart with embedded data.',
     padding: { left: 5, top: 10, right: 5, bottom: 5 },
     data: {
-      name: 'table'
+      name: 'table',
     },
     layer: [
       {
@@ -80,11 +80,10 @@ const TypesChart: React.FunctionComponent<Props> = ({
   const title = () => {
     return (
       <React.Fragment>
-        Distribution by work type
+        Distribution by license
       </React.Fragment>
     )
   }
-
 
   return (
     <div className="panel panel-transparent">
@@ -101,4 +100,4 @@ const TypesChart: React.FunctionComponent<Props> = ({
   )
 }
 
-export default TypesChart
+export default LicenseChart

--- a/src/components/OrganizationContainer/OrganizationContainer.tsx
+++ b/src/components/OrganizationContainer/OrganizationContainer.tsx
@@ -414,7 +414,7 @@ const OrganizationContainer: React.FunctionComponent<Props> = ({ rorId }) => {
 
     const noLicenseValue: ContentFacet = {
       id: 'no-license',
-      title: 'no license',
+      title: 'No License',
       count: data.organization.works.totalCount - data.organization.works.licenses.reduce((a, b) => a + (b['count'] || 0), 0)
     }
     let licenses = clone(data.organization.works.licenses)

--- a/src/components/OrganizationContainer/OrganizationContainer.tsx
+++ b/src/components/OrganizationContainer/OrganizationContainer.tsx
@@ -418,7 +418,7 @@ const OrganizationContainer: React.FunctionComponent<Props> = ({ rorId }) => {
       count: data.organization.works.totalCount - data.organization.works.licenses.reduce((a, b) => a + (b['count'] || 0), 0)
     }
     let licenses = clone(data.organization.works.licenses)
-    licenses.push(noLicenseValue)
+    licenses.unshift(noLicenseValue)
     licenses = licenses.map((x) => ({
       id: x.id,
       title: x.title,

--- a/src/components/Person/Person.tsx
+++ b/src/components/Person/Person.tsx
@@ -153,7 +153,7 @@ const Person: React.FunctionComponent<Props> = ({ person }) => {
       count: person.works.totalCount - person.works.licenses.reduce((a, b) => a + (b['count'] || 0), 0)
     }
     let licenses = clone(person.works.licenses)
-    licenses.push(noLicenseValue)
+    licenses.unshift(noLicenseValue)
     licenses = licenses.map((x) => ({
       id: x.id,
       title: x.title,

--- a/src/components/Person/Person.tsx
+++ b/src/components/Person/Person.tsx
@@ -3,11 +3,13 @@ import { Alert, Row, Col } from 'react-bootstrap'
 import { DoiType } from '../DoiContainer/DoiContainer'
 import DoiRelatedContent from '../DoiRelatedContent/DoiRelatedContent'
 import TypesChart from '../TypesChart/TypesChart'
+import LicenseChart from '../LicenseChart/LicenseChart'
 import PersonMetadata from '../PersonMetadata/PersonMetadata'
 import ProductionChart from '../ProductionChart/ProductionChart'
 import Pager from '../Pager/Pager'
 import { orcidFromUrl, compactNumbers } from '../../utils/helpers'
 import Pluralize from 'react-pluralize'
+import clone from 'lodash/clone'
 
 export interface PersonRecord {
   id: string
@@ -143,23 +145,42 @@ const Person: React.FunctionComponent<Props> = ({ person }) => {
       title: x.title,
       count: x.count
     }))
+    const noLicenseValue: ContentFacet = {
+      id: 'no-license',
+      title: 'no license',
+      count: person.works.totalCount - person.works.licenses.reduce((a, b) => a + (b['count'] || 0), 0)
+    }
+    let licenses = clone(person.works.licenses)
+    licenses.push(noLicenseValue)
+    licenses = licenses.map((x) => ({
+      id: x.id,
+      title: x.title,
+      count: x.count
+    }))
 
     return (
       <React.Fragment>
         <Row>
-          <Col xs={8}>
+          <Col xs={6}>
             <ProductionChart
               data={published}
               doiCount={person.works.totalCount}
             ></ProductionChart>
           </Col>
-          <Col xs={4}>
+          <Col xs={3}>
             <TypesChart
               data={resourceTypes}
               legend={false}
               count={person.works.totalCount}
             ></TypesChart>
           </Col>
+          <Col xs={3}>
+          <LicenseChart
+            data={licenses}
+            legend={false}
+            count={person.works.totalCount}
+          ></LicenseChart>
+        </Col>
         </Row>
       </React.Fragment>
     )

--- a/src/components/Person/Person.tsx
+++ b/src/components/Person/Person.tsx
@@ -149,7 +149,7 @@ const Person: React.FunctionComponent<Props> = ({ person }) => {
     }))
     const noLicenseValue: ContentFacet = {
       id: 'no-license',
-      title: 'no license',
+      title: 'No License',
       count: person.works.totalCount - person.works.licenses.reduce((a, b) => a + (b['count'] || 0), 0)
     }
     let licenses = clone(person.works.licenses)

--- a/src/components/Person/Person.tsx
+++ b/src/components/Person/Person.tsx
@@ -37,6 +37,8 @@ interface Works {
   resourceTypes: ContentFacet[]
   pageInfo: PageInfo
   published: ContentFacet[]
+  licenses: ContentFacet[]
+  languages: ContentFacet[]
   nodes: DoiType[]
 }
 

--- a/src/components/PersonContainer/PersonContainer.tsx
+++ b/src/components/PersonContainer/PersonContainer.tsx
@@ -100,6 +100,8 @@ interface Works {
   published: ContentFacet[]
   licenses: ContentFacet[]
   languages: ContentFacet[]
+  fieldsOfScience: ContentFacet[]
+  registrationAgencies: ContentFacet[]
   affiliations: ContentFacet[]
   repositories: ContentFacet[]
   nodes: DoiType[]
@@ -262,6 +264,64 @@ const PersonContainer: React.FunctionComponent<Props> = ({ orcid }) => {
               {orcidRecord.works.resourceTypes.map((facet) => (
                 <li key={facet.id}>
                   {facetLink('resource-type', facet.id)}
+                  <div className="facet-title">{facet.title}</div>
+                  <span className="number pull-right">
+                    {facet.count.toLocaleString('en-US')}
+                  </span>
+                  <div className="clearfix" />
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+
+        {orcidRecord.works.licenses.length > 0 && (
+          <div className="panel facets add">
+            <div className="panel-body">
+              <h4>License</h4>
+              <ul>
+                {orcidRecord.works.licenses.map((facet) => (
+                  <li key={facet.id}>
+                    {facetLink('license', facet.id)}
+                    <div className="facet-title">{facet.title}</div>
+                    <span className="number pull-right">
+                      {facet.count.toLocaleString('en-US')}
+                    </span>
+                    <div className="clearfix" />
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        )}
+
+        {orcidRecord.works.languages.length > 0 && (
+          <div className="panel facets add">
+            <div className="panel-body">
+              <h4>Language</h4>
+              <ul>
+                {orcidRecord.works.languages.map((facet) => (
+                  <li key={facet.id}>
+                    {facetLink('language', facet.id)}
+                    <div className="facet-title">{facet.title}</div>
+                    <span className="number pull-right">
+                      {facet.count.toLocaleString('en-US')}
+                    </span>
+                    <div className="clearfix" />
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        )}
+
+        <div className="panel facets add">
+          <div className="panel-body">
+            <h4>DOI Registration Agency</h4>
+            <ul>
+              {orcidRecord.works.registrationAgencies.map((facet) => (
+                <li key={facet.id}>
+                  {facetLink('registration-agency', facet.id)}
                   <div className="facet-title">{facet.title}</div>
                   <span className="number pull-right">
                     {facet.count.toLocaleString('en-US')}

--- a/src/components/PersonContainer/PersonContainer.tsx
+++ b/src/components/PersonContainer/PersonContainer.tsx
@@ -48,11 +48,6 @@ export const DOI_GQL = gql`
       citationCount
       viewCount
       downloadCount
-      # affiliation {
-      #   name
-      #   id
-      # }
-
       works(first: 25, after: $cursor, published: $published, resourceTypeId: $resourceTypeId, fieldOfScience: $fieldOfScience, language: $language, license: $license, registrationAgency: $registrationAgency, repositoryId: $repositoryId) {
         ...WorkConnectionFragment
         nodes {
@@ -103,6 +98,8 @@ interface Works {
   resourceTypes: ContentFacet[]
   pageInfo: PageInfo
   published: ContentFacet[]
+  licenses: ContentFacet[]
+  languages: ContentFacet[]
   affiliations: ContentFacet[]
   repositories: ContentFacet[]
   nodes: DoiType[]

--- a/src/components/ProductionChart/ProductionChart.tsx
+++ b/src/components/ProductionChart/ProductionChart.tsx
@@ -115,7 +115,7 @@ const ProductionChart: React.FunctionComponent<Props> = ({
   const title = () => {
     return (
       <React.Fragment>
-         Distribution by publication year
+         <h4>Works by publication year</h4>
       </React.Fragment>
     )
   }

--- a/src/components/ProductionChart/ProductionChart.tsx
+++ b/src/components/ProductionChart/ProductionChart.tsx
@@ -37,6 +37,7 @@ const ProductionChart: React.FunctionComponent<Props> = ({
     data: {
       name: 'table'
     },
+    padding: { left: 5, top: 5, right: 5, bottom: 5 },
     transform: [
       {
         calculate: 'toNumber(datum.title)',
@@ -50,7 +51,7 @@ const ProductionChart: React.FunctionComponent<Props> = ({
         filter: 'toNumber(datum.title) >' + lowerBoundYear
       }
     ],
-    width: yearsDomain * 25,
+    width: yearsDomain * 22,
     mark: {
       type: 'bar',
       cursor: 'pointer',

--- a/src/components/TypesChart/TypesChart.test.tsx
+++ b/src/components/TypesChart/TypesChart.test.tsx
@@ -4,8 +4,6 @@ import React from 'react'
 import { mount } from 'cypress-react-unit-test'
 import TypesChart from './TypesChart'
 
-
-
 describe('TypesChart Component', () => {
   let data
   beforeEach(function () {

--- a/src/components/TypesChart/TypesChart.tsx
+++ b/src/components/TypesChart/TypesChart.tsx
@@ -80,11 +80,10 @@ const TypesChart: React.FunctionComponent<Props> = ({
   const title = () => {
     return (
       <React.Fragment>
-        Distribution by work type
+        <h4>Works by work type</h4>
       </React.Fragment>
     )
   }
-
 
   return (
     <div className="panel panel-transparent">

--- a/src/styles.css
+++ b/src/styles.css
@@ -209,3 +209,7 @@ ul.nav.nav-tabs li span {
 .alert-works {
   margin: 10px;
 }
+
+.types-chart text, .license-chart text {
+  font-size: 27px;
+}


### PR DESCRIPTION
## Purpose
Show donut chart of license information, similar to work type.

## Approach
Reuse donut chart. Calculate missing value count. Adjust donut chart size and bar chart width. Do the same chart(s) for organization display.

<img width="1064" alt="Bildschirmfoto 2020-08-13 um 23 03 50" src="https://user-images.githubusercontent.com/23151/90186955-4f755800-ddb9-11ea-9470-67ca7acb24fe.png">

