### PR TITLE
Provide download link for single doi

### DIFF
--- a/src/components/WorkContainer/WorkContainer.tsx
+++ b/src/components/WorkContainer/WorkContainer.tsx
@@ -30,6 +30,7 @@ export const DOI_GQL = gql`
   ) {
     work(id: $id) {
       ...WorkFragment
+      contentUrl
       formattedCitation
       viewsOverTime {
         yearMonth
@@ -82,6 +83,7 @@ export interface WorkType {
   id: string
   doi: string
   url: string
+  contentUrl: string
   types: {
     resourceTypeGeneral?: string
     resourceType?: string

--- a/src/components/WorkMetadata/WorkMetadata.tsx
+++ b/src/components/WorkMetadata/WorkMetadata.tsx
@@ -50,6 +50,8 @@ const WorkMetadata: React.FunctionComponent<Props> = ({
       ? metadata.id
       : 'https://doi.org/' + metadata.doi
 
+  const showDownloadLink = metadata.contentUrl
+  
   const searchtitle = () => {
     if (!metadata.titles[0])
       return (
@@ -336,6 +338,30 @@ const WorkMetadata: React.FunctionComponent<Props> = ({
     <Tooltip id="tooltipLanguage">The primary language of the content.</Tooltip>
   )
 
+  const tooltipDownload = (
+    <Tooltip id="tooltipDownload">
+      Download link to PDF provided by Unpaywall.
+    </Tooltip>
+  )
+
+  const tooltipEnvelope = (
+    <Tooltip id="tooltipEnvelope">
+      Share this page via email.
+    </Tooltip>
+  )
+
+  const tooltipFacebook = (
+    <Tooltip id="tooltipFacebook">
+      Share this page via Facebook.
+    </Tooltip>
+  )
+
+  const tooltipTwitter = (
+    <Tooltip id="tooltipTwitter">
+      Share this page via Twitter.
+    </Tooltip>
+  )
+
   const tags = () => {
     return (
       <div className="tags">
@@ -424,20 +450,35 @@ const WorkMetadata: React.FunctionComponent<Props> = ({
         <a href={handleUrl}>
           <FontAwesomeIcon icon={faExternalLinkAlt} size="sm" /> {handleUrl}
         </a>
-        <span className="actions">
-          <EmailShareButton url={pageUrl} title={title}>
-            <FontAwesomeIcon icon={faEnvelope} />
-          </EmailShareButton>
+        <span className="actions with-label">
+          {showDownloadLink && (
+            <OverlayTrigger placement="top" overlay={tooltipDownload}>
+              <a href={metadata.contentUrl} target="_blank" rel="noreferrer">
+                <FontAwesomeIcon icon={faDownload} size="sm" /> Download
+              </a>
+            </OverlayTrigger>
+          )}
         </span>
         <span className="actions">
-          <TwitterShareButton url={pageUrl} title={title}>
-            <FontAwesomeIcon icon={faTwitter} />
-          </TwitterShareButton>
+          <OverlayTrigger placement="top" overlay={tooltipEnvelope}>
+            <EmailShareButton url={pageUrl} title={title}>
+              <FontAwesomeIcon icon={faEnvelope} />
+            </EmailShareButton>
+          </OverlayTrigger>
         </span>
         <span className="actions">
-          <FacebookShareButton url={pageUrl} title={title}>
-            <FontAwesomeIcon icon={faFacebook} />
-          </FacebookShareButton>
+          <OverlayTrigger placement="top" overlay={tooltipTwitter}>
+            <TwitterShareButton url={pageUrl} title={title}>
+              <FontAwesomeIcon icon={faTwitter} />
+            </TwitterShareButton>
+          </OverlayTrigger>
+        </span>
+        <span className="actions">
+          <OverlayTrigger placement="top" overlay={tooltipFacebook}>
+            <FacebookShareButton url={pageUrl} title={title}>
+              <FontAwesomeIcon icon={faFacebook} /> Share
+            </FacebookShareButton>
+          </OverlayTrigger>
         </span>
       </div>
     )

--- a/src/components/WorkMetadata/WorkMetadata.tsx
+++ b/src/components/WorkMetadata/WorkMetadata.tsx
@@ -450,15 +450,15 @@ const WorkMetadata: React.FunctionComponent<Props> = ({
         <a href={handleUrl}>
           <FontAwesomeIcon icon={faExternalLinkAlt} size="sm" /> {handleUrl}
         </a>
-        <span className="actions with-label">
-          {showDownloadLink && (
+        {showDownloadLink && (
+          <span className="actions with-label">
             <OverlayTrigger placement="top" overlay={tooltipDownload}>
               <a href={metadata.contentUrl} target="_blank" rel="noreferrer">
                 <FontAwesomeIcon icon={faDownload} size="sm" /> Download
               </a>
             </OverlayTrigger>
-          )}
-        </span>
+          </span>
+        )}
         <span className="actions">
           <OverlayTrigger placement="top" overlay={tooltipEnvelope}>
             <EmailShareButton url={pageUrl} title={title}>

--- a/src/styles.css
+++ b/src/styles.css
@@ -28,6 +28,10 @@ svg[data-icon='quote-left'] {
   cursor: pointer;
 }
 
+.panel-footer span.actions.with-label {
+  margin-right: 2.25em;
+}
+
 .panel-footer a {
   margin-right: 3em;
 }


### PR DESCRIPTION
## Purpose
Provide direct link to PDF if content is from Crossref and PDF link returned from Unpaywall API.

closes: #114

## Approach
Implemented in the GraphQL API as `contentUrl` field. Only check for single DOI pages but not queries, as this requires a live API call to Unpaywall.

## Types of changes

- [ ] New feature (non-breaking change which adds functionality)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
