### PR TITLE
Show person employment with links to organizations

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,1 @@
 NEXT_PUBLIC_API_URL=https://api.stage.datacite.org
-

--- a/cypress/fixtures/person.json
+++ b/cypress/fixtures/person.json
@@ -6,6 +6,15 @@
   "citationCount":33,
   "viewCount":0,
   "downloadCount":4504,
+  "employment": [
+    {
+      "organizationId": null,
+      "organizationName": "DataCite",
+      "roleTitle": "Application Developer",
+      "startDate": "2016-08-01T00:00:00Z",
+      "endDate": null
+    }
+  ],
   "works":{
     "pageInfo":{
       "endCursor":"MQ",

--- a/cypress/integration/personContainer.test.ts
+++ b/cypress/integration/personContainer.test.ts
@@ -16,6 +16,15 @@ describe('PersonContainer', () => {
     cy.get('.panel-body h3.work', { timeout: 30000 }).contains('K. J. Garza')
   })
 
+  it('employment', () => {
+    cy.get('#person-employment', { timeout: 30000 }).contains('Employment')
+    cy.get('.panel.employment').should(($employment) => {
+      expect($employment).to.have.length(1)
+      expect($employment.eq(0)).to.contain('DataCite')
+      expect($employment.eq(0)).to.contain('Since August 2016')
+    })
+  })
+
   it('links', () => {
     cy.get('.people-links').should(($link) => {
       expect($link).to.have.length(2)

--- a/src/components/Person/Person.tsx
+++ b/src/components/Person/Person.tsx
@@ -1,7 +1,10 @@
 import React from 'react'
 import { Alert } from 'react-bootstrap'
+import { useFeature } from 'flagged'
+
 import { WorkType } from '../WorkContainer/WorkContainer'
 import PersonMetadata from '../PersonMetadata/PersonMetadata'
+import PersonEmployment from '../PersonEmployment/PersonEmployment'
 // import { compactNumbers } from '../../utils/helpers'
 // import Pluralize from 'react-pluralize'
 
@@ -12,6 +15,7 @@ export interface PersonRecord {
   identifiers: Identifier[]
   alternateName?: string[]
   country: Attribute
+  employment: EmploymentRecord[]
   name: string
   givenName: string
   familyName: string
@@ -21,6 +25,14 @@ export interface PersonRecord {
 export interface Attribute {
   name: string
   id: string
+}
+
+export interface EmploymentRecord {
+  organizationId: string
+  organizationName: string
+  roleTitle: string
+  startDate: Date
+  endDate: Date
 }
 
 interface Works {
@@ -61,6 +73,8 @@ type Props = {
 
 const Person: React.FunctionComponent<Props> = ({ person }) => {
   if (!person) return <Alert bsStyle="warning">No person found.</Alert>
+
+  const showEmployment = person.employment.length > 0 && useFeature('personEmployment')
 
   // const workCount = () => {
   //   if (person.works.totalCount == 0) {
@@ -131,6 +145,17 @@ const Person: React.FunctionComponent<Props> = ({ person }) => {
     <>
       <h3 className="member-results">{person.id}</h3>
       <PersonMetadata metadata={person} />
+      
+      {showEmployment && (
+        <h3 className="member-results" id="person-employment">Employment</h3>
+      )}
+      {showEmployment && (
+        person.employment.map((item) => (
+          <div className="panel panel-transparent employment" key={item.organizationName}>
+            <PersonEmployment employment={item} />
+          </div>
+        )
+      ))}
     </>
   )
 }

--- a/src/components/PersonContainer/PersonContainer.tsx
+++ b/src/components/PersonContainer/PersonContainer.tsx
@@ -51,6 +51,13 @@ export const DOI_GQL = gql`
       alternateName
       givenName
       familyName
+      employment {
+        organizationId
+        organizationName
+        roleTitle
+        startDate
+        endDate
+      }
       works(
         first: 25
         query: $query
@@ -83,6 +90,7 @@ export interface PersonType {
   givenName: string
   familyName: string
   alternateName: string[]
+  employment: Organization[]
   pageInfo: PageInfo
   works: Works
 }
@@ -96,6 +104,14 @@ interface Identifiers {
   identifierType: string
   identifierUrl: string
   identifier: string
+}
+
+interface Organization {
+  organizationId: string
+  organizationName: string
+  roleTitle: string
+  startDate: Date
+  endDate: Date
 }
 
 interface Country {

--- a/src/components/PersonEmployment/PersonEmployment.test.tsx
+++ b/src/components/PersonEmployment/PersonEmployment.test.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import { mount } from 'cypress-react-unit-test'
+import PersonEmployment from './PersonEmployment'
+
+describe('PersonEmployment Component', () => {
+  let data
+
+  beforeEach(function () {
+    cy.fixture('person.json').then((d) => {
+      data = d.employment
+    })
+  })
+
+  it('employment', () => {
+    mount(<PersonEmployment employment={data} />)
+    cy.get('h3.work').contains('DataCite')
+  })
+})

--- a/src/components/PersonEmployment/PersonEmployment.tsx
+++ b/src/components/PersonEmployment/PersonEmployment.tsx
@@ -1,0 +1,66 @@
+import React from 'react'
+import Link from 'next/link'
+
+import { rorFromUrl } from '../../utils/helpers'
+import { EmploymentRecord } from '../Person/Person'
+
+type Props = {
+  employment: EmploymentRecord
+}
+
+const PersonEmployment: React.FunctionComponent<Props> = ({ employment }) => {
+  const name = () => {
+    if (!employment.organizationId)
+      return <h3 className="work">{employment.organizationName}</h3>
+
+    return (
+      <h3 className="work">
+        <Link
+          href="/ror.org/[...organization]"
+          as={`/ror.org${rorFromUrl(employment.organizationId)}`}
+        >
+          <a>{employment.organizationName}</a>
+        </Link>
+      </h3>
+    )
+  }
+
+  const range = () => {
+    if (!employment.endDate)
+      return (
+        <div className="duration">
+          Since{' '}
+          {new Date(employment.startDate).toLocaleDateString('en-US', {
+            year: 'numeric',
+            month: 'long'
+          })}
+        </div>
+      )
+
+    return (
+      <div className="duration">
+        {new Date(employment.startDate).toLocaleDateString('en-US', {
+          year: 'numeric',
+          month: 'long'
+        })}{' '}
+        to{' '}
+        {new Date(employment.endDate).toLocaleDateString('en-US', {
+          year: 'numeric',
+          month: 'long'
+        })}
+      </div>
+    )
+  }
+
+  return (
+    <div className="panel-body">
+      {name()}
+      {employment.roleTitle && (
+        <div className="role-title">{employment.roleTitle}</div>
+      )}
+      {employment.startDate && range()}
+    </div>
+  )
+}
+
+export default PersonEmployment

--- a/src/components/WorkMetadata/WorkMetadata.tsx
+++ b/src/components/WorkMetadata/WorkMetadata.tsx
@@ -52,7 +52,7 @@ const WorkMetadata: React.FunctionComponent<Props> = ({
       : 'https://doi.org/' + metadata.doi
 
   const showDownloadLink = metadata.contentUrl && useFeature('downloadLink')
-  
+
   const searchtitle = () => {
     if (!metadata.titles[0])
       return (

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -38,12 +38,23 @@ class MyApp extends App<IProps> {
     // don't show consent cookie in production yet
     const consentCookie =
       process.env.NEXT_PUBLIC_API_URL === 'https://api.stage.datacite.org'
+
     // don't show download link in production yet
     const downloadLink =
       process.env.NEXT_PUBLIC_API_URL === 'https://api.stage.datacite.org'
-      
+
+    // don't show person employment in production yet
+    const personEmployment =
+      process.env.NEXT_PUBLIC_API_URL === 'https://api.stage.datacite.org'
+
     return (
-      <FlagsProvider features={{ consentCookie: consentCookie, downloadLink: downloadLink }}>
+      <FlagsProvider
+        features={{
+          consentCookie,
+          downloadLink,
+          personEmployment
+        }}
+      >
         <ApolloProvider client={apollo}>
           {/* adds the apollo provider to provide it's children with the apollo scope. */}
           <Component {...pageProps} />


### PR DESCRIPTION
## Purpose
Show employment section on the person page, fetching the data from the person's ORCID record. In addition we are linking to the organization page for the employer.

closes: #116

## Approach
Do a second API call to the ORCID REST API to fetch employment information (in addition to the `/person` endpoint). In the GraphQL API, use a Wikidata SPARQL query to find the ROR ID for an employer. Use a feature flag and only show this on stage.

#### Open Questions and Pre-Merge TODOs
- [ ] fix PersonEmployment unit test (E2E test works)
- [ ] fix lookup of organization identifiers using the GRID ID in Wikidata

## Types of changes

- [ ] New feature (non-breaking change which adds functionality)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
