### PR TITLE
Support for external organisation id in path

### DIFF
--- a/cypress/integration/fundrefContainer.test.ts
+++ b/cypress/integration/fundrefContainer.test.ts
@@ -1,0 +1,27 @@
+/// <reference types="cypress" />
+
+describe("FundrefContainer", () => {
+  beforeEach(() => {
+    cy.setCookie('_consent', 'true')
+    cy.visit('/doi.org/10.13039/100010367')
+  })
+
+  it("id", () => {
+    cy.get('h3.member-results',  { timeout: 30000 })
+      .contains('https://ror.org/052gg0110')
+  })
+
+  it("name", () => {
+    cy.get('.panel-body h3.work',  { timeout: 30000 })
+      .contains('University of Oxford')
+  })
+
+  it('actions', () => {
+    cy.get('.actions', { timeout: 30000 })
+    .should(($action) => {
+      expect($action).to.have.length.at.least(3)
+    })
+  })
+})
+
+export {}

--- a/cypress/integration/gridContainer.test.ts
+++ b/cypress/integration/gridContainer.test.ts
@@ -1,0 +1,27 @@
+/// <reference types="cypress" />
+
+describe("GridContainer", () => {
+  beforeEach(() => {
+    cy.setCookie('_consent', 'true')
+    cy.visit('/grid.ac/institutes/grid.4991.5')
+  })
+
+  it("id", () => {
+    cy.get('h3.member-results',  { timeout: 30000 })
+      .contains('https://ror.org/052gg0110')
+  })
+
+  it("name", () => {
+    cy.get('.panel-body h3.work',  { timeout: 30000 })
+      .contains('University of Oxford')
+  })
+
+  it('actions', () => {
+    cy.get('.actions', { timeout: 30000 })
+    .should(($action) => {
+      expect($action).to.have.length.at.least(3)
+    })
+  })
+})
+
+export {}

--- a/src/pages/doi.org/[...doi].tsx
+++ b/src/pages/doi.org/[...doi].tsx
@@ -1,24 +1,33 @@
 import React from 'react'
 import Layout from '../../components/Layout/Layout'
 import WorkContainer from '../../components/WorkContainer/WorkContainer'
+import OrganizationContainer from '../../components/OrganizationContainer/OrganizationContainer'
 import { GetServerSideProps } from 'next'
 import { useQueryState } from 'next-usequerystate'
 
 const DoisPage = ({ doiPath }) => {
   const [searchQuery] = useQueryState<string>('query')
 
+  // if DOI is a Crossref Funder ID
+  if (doiPath.startsWith('10.13039'))
+    return (
+      <Layout path={doiPath} >
+        <OrganizationContainer crossrefFunderId={doiPath} searchQuery={searchQuery} />
+      </Layout>
+    )
+
   return (
-    <Layout path={'/doi.org/' + doiPath.join('/')} >
-      <WorkContainer item={doiPath.join('/')} searchQuery={searchQuery} />
+    <Layout path={'/doi.org/' + doiPath } >
+      <WorkContainer item={doiPath} searchQuery={searchQuery} />
     </Layout>
   )
 }
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
-  const doiPath = context.params.doi
+  const doiPath = (context.params.doi as String[]).join('/')
 
   return {
-    props: { doiPath } // will be passed to the page component as props
+    props: { doiPath }
   }
 }
 

--- a/src/pages/grid.ac/[...grid].tsx
+++ b/src/pages/grid.ac/[...grid].tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import Layout from '../../components/Layout/Layout'
+import OrganizationContainer from '../../components/OrganizationContainer/OrganizationContainer'
+import { GetServerSideProps } from 'next'
+import { useQueryState } from 'next-usequerystate'
+
+const GridPage = ({ gridPath }) => {
+  const [searchQuery] = useQueryState<string>('query')
+
+  return (
+    <Layout path={gridPath} >
+      <OrganizationContainer gridId={gridPath} searchQuery={searchQuery} />
+    </Layout>
+  )
+}
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const gridPath = 'grid.ac/' + (context.params.grid as String[]).join('/')
+
+  return {
+    props: { gridPath }
+  }
+}
+
+export default GridPage


### PR DESCRIPTION
## Purpose
Facilitate crosslinking within DataCite Commons when only external organization identifiers are known, e.g. Crossref Funder ID for funding in work metadata, or GRID ID for person employments. This avoids the overhead of mapping the identifiers in the API. This feature also facilitates incoming links to DataCite Commons.

closes: #118

## Approach
Run the GraphQL query with the external identifier. Use the router to push to the default path for an organization once the ROR ID is known from the GraphQL query.

## Types of changes

- [ ] New feature (non-breaking change which adds functionality)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
