### PR TITLE
Show funding information per work. 

### DIFF
--- a/cypress/fixtures/doi.json
+++ b/cypress/fixtures/doi.json
@@ -26,6 +26,16 @@
     "id": "datacite",
     "name": "DataCite"
   },
+  "fundingReferences": [
+    {
+    "awardUri": "info:eu-repo/grantAgreement/EC/FP7/611832/",
+    "awardTitle": "Whole-body Adaptive Locomotion and Manipulation",
+    "funderName": "European Commission",
+    "awardNumber": "611832",
+    "funderIdentifier": "https://doi.org/10.13039/501100000780",
+    "funderIdentifierType": "Crossref Funder ID"
+    }
+    ],
   "formattedCitation": "Gallardo-Escárate, C., Valenzuela-Muñoz, V., Núñez-Acuña, G., &amp; Haye, P. (2014). <i>Data from: SNP discovery and gene annotation in the surf clam Mesodesma donacium</i> (Version 1) [Data set]. Dryad. <a href='https://doi.org/10.5061/DRYAD.8JD18'>https://doi.org/10.5061/DRYAD.8JD18</a>",
   "citationCount": 4,
   "viewCount": 8,

--- a/cypress/integration/workContainer.test.ts
+++ b/cypress/integration/workContainer.test.ts
@@ -36,6 +36,7 @@
 
 describe('workContainer with usage', () => {
   before(() => {
+    cy.setCookie('_consent', 'true')
     cy.visit(`/doi.org/${encodeURIComponent('10.70048/findable101')}`)
   })
 
@@ -43,6 +44,22 @@ describe('workContainer with usage', () => {
     cy.get('.mark-rect > path', { timeout: 10000 })
       .should('be.visible')
       .should('have.length', 4)
+  })
+})
+
+describe('workContainer with funding', () => {
+  before(() => {
+    cy.setCookie('_consent', 'true')
+    cy.visit(`/doi.org/${encodeURIComponent('10.70131/test_doi_5d2bc48749f14')}`)
+  })
+
+  it('funding', () => {
+    cy.get('#work-funding', { timeout: 30000 }).contains('Funding')
+    cy.get('.panel.funding').should(($funding) => {
+      expect($funding).to.have.length(2)
+      expect($funding.eq(0)).to.contain('Water Ice')
+      expect($funding.eq(1)).to.contain('ARC')
+    })
   })
 })
 

--- a/src/components/Work/Work.tsx
+++ b/src/components/Work/Work.tsx
@@ -1,10 +1,13 @@
 import React from 'react'
 import { Tabs, Tab, Alert } from 'react-bootstrap'
 import Pluralize from 'react-pluralize'
+import { useFeature } from 'flagged'
+
 import { compactNumbers } from '../../utils/helpers'
 import { WorkType } from '../WorkContainer/WorkContainer'
 import CitationFormatter from '../CitationFormatter/CitationFormatter'
 import WorkMetadata from '../WorkMetadata/WorkMetadata'
+import WorkFunding from '../WorkFunding/WorkFunding'
 import UsageChart from '../UsageChart/UsageChart'
 
 type Props = {
@@ -13,6 +16,8 @@ type Props = {
 
 const DoiPresentation: React.FunctionComponent<Props> = ({ doi }) => {
   if (!doi) return <Alert bsStyle="warning">No works found.</Alert>
+
+  const showFunding = doi.fundingReferences && useFeature('workFunding')
 
   const exportMetadata = () => {
     const apiUrl =
@@ -200,6 +205,16 @@ const DoiPresentation: React.FunctionComponent<Props> = ({ doi }) => {
       <WorkMetadata metadata={doi} linkToExternal={true}></WorkMetadata>
       {exportMetadata()}
       {formattedCitation()}
+      {showFunding && (
+        <h3 className="member-results" id="work-funding">Funding</h3>
+      )}
+      {showFunding && (
+        doi.fundingReferences.map((item) => (
+          <div className="panel panel-transparent funding" key={item.funderName}>
+            <WorkFunding funding={item} />
+          </div>
+        )
+      ))}
       {analyticsBar()}
     </>
   )

--- a/src/components/WorkContainer/WorkContainer.tsx
+++ b/src/components/WorkContainer/WorkContainer.tsx
@@ -31,6 +31,14 @@ export const DOI_GQL = gql`
     work(id: $id) {
       ...WorkFragment
       contentUrl
+      fundingReferences {
+        funderIdentifier
+        funderIdentifierType
+        funderName
+        awardTitle
+        awardUri
+        awardNumber
+      }
       formattedCitation
       viewsOverTime {
         yearMonth
@@ -115,6 +123,7 @@ export interface WorkType {
   }
   registered?: Date
   formattedCitation?: string
+  fundingReferences?: FundingReference[]
   citationCount?: number
   citations?: {
     published: Facet[]
@@ -167,6 +176,15 @@ interface Rights {
   rightsIdentifier: string
 }
 
+export interface FundingReference {
+  funderIdentifier?: string
+  funderIdentifierType?: string
+  funderName?: string
+  awardUri?: string
+  awardTitle?: string
+  awardNumber?: string
+}
+
 interface FieldOfScience {
   id: string
   name: string
@@ -174,6 +192,15 @@ interface FieldOfScience {
 
 interface Description {
   description: string
+}
+
+interface fundingReferences {
+  funderIdentifier: string
+  funderIdentifierType: string
+  funderName: string
+  awardUri: string
+  awardTitle: string
+  awardNumber: string
 }
 
 interface PageInfo {
@@ -213,7 +240,10 @@ interface QueryVar {
   registrationAgency: string
 }
 
-const WorkContainer: React.FunctionComponent<Props> = ({ item, searchQuery }) => {
+const WorkContainer: React.FunctionComponent<Props> = ({
+  item,
+  searchQuery
+}) => {
   const [cursor] = useQueryState('cursor', { history: 'push' })
   const [published] = useQueryState('published', { history: 'push' })
   const [resourceType] = useQueryState('resource-type', { history: 'push' })
@@ -241,10 +271,7 @@ const WorkContainer: React.FunctionComponent<Props> = ({ item, searchQuery }) =>
     }
   })
 
-  if (loading)
-    return (
-      <Loading />
-    )
+  if (loading) return <Loading />
 
   if (error)
     return (

--- a/src/components/WorkFunding/WorkFunding.tsx
+++ b/src/components/WorkFunding/WorkFunding.tsx
@@ -1,0 +1,68 @@
+import React from 'react'
+import Link from 'next/link'
+
+import { FundingReference } from '../WorkContainer/WorkContainer'
+import { doiFromUrl } from '../../utils/helpers'
+
+type Props = {
+  funding: FundingReference
+}
+
+const WorkFunding: React.FunctionComponent<Props> = ({ funding }) => {
+  console.log(funding)
+  const funder = () => {
+    if (funding.funderIdentifier && funding.funderIdentifier.startsWith('https://doi.org/10.13039'))
+      return (
+        <h3 className="work">
+          <Link
+            href="/doi.org/[...doi]"
+            as={`/doi.org${doiFromUrl(funding.funderIdentifier)}`}
+          >
+            <a>{funding.funderName}</a>
+          </Link>
+        </h3>
+      )
+
+    return <h3 className="work">{funding.funderName}</h3>
+  }
+
+  const hasAward = funding.awardTitle || funding.awardNumber || funding.awardUri
+
+  const award = () => {
+    let title = 'No award title or number'
+    if (funding.awardTitle && funding.awardNumber) {
+      title = funding.awardTitle + ' (' + funding.awardNumber + ')'
+    } else if (funding.awardTitle) {
+      title = funding.awardTitle
+    } else if (funding.awardNumber) {
+      title = funding.awardNumber
+    }
+
+    let url = null
+    if (funding.awardUri && funding.awardUri.startsWith('http')) {
+      url = funding.awardUri
+    } else if (funding.awardUri && funding.awardUri.startsWith('info:eu-repo/grantAgreement')) {
+      // provide url for EC funding
+      url = 'https://cordis.europa.eu/project/id/' + funding.awardNumber
+    }
+
+    if (!url) return <div className="award">{title}</div>
+    
+    return (
+      <div className="award">
+        <a target="_blank" rel="noreferrer" href={url}>
+          {title}
+        </a>
+      </div>
+    )
+  }
+
+  return (
+    <div className="panel-body">
+      {funding.funderName && funder()}
+      {hasAward && award()}
+    </div>
+  )
+}
+
+export default WorkFunding

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -47,12 +47,17 @@ class MyApp extends App<IProps> {
     const personEmployment =
       process.env.NEXT_PUBLIC_API_URL === 'https://api.stage.datacite.org'
 
-    return (
+    // don't show work funding in production yet
+    const workFunding =
+      process.env.NEXT_PUBLIC_API_URL === 'https://api.stage.datacite.org'
+    
+      return (
       <FlagsProvider
         features={{
           consentCookie,
           downloadLink,
-          personEmployment
+          personEmployment,
+          workFunding
         }}
       >
         <ApolloProvider client={apollo}>

--- a/src/utils/helpers.tsx
+++ b/src/utils/helpers.tsx
@@ -12,6 +12,10 @@ export const compactNumbers = (num) => {
   return num
 }
 
+export const doiFromUrl = (doiUrl: string) => {
+  return doiUrl ? doiUrl.substring(15) : null
+}
+
 export const orcidFromUrl = (orcidUrl: string) => {
   return orcidUrl ? orcidUrl.substring(17) : null
 }


### PR DESCRIPTION
## Purpose
Show funding information for a specific work, and link to funder organization page in `akita` if a Crossref Funder ID is included. This works for both Crossref and DataCite DOIs and implements bi-directional linking (funder => works, and work => funder).

closes: #120

## Approach
Use `WorkFunding` component. Link to funding organization using the Crossref Funder ID and the support for external organizational identifiers implemented in #118.

#### Open Questions and Pre-Merge TODOs
- [ ] look into providing custom award URLs for awards from important funders.

## Types of changes

- [ ] New feature (non-breaking change which adds functionality)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.

<img width="1068" alt="Bildschirmfoto 2020-09-03 um 12 41 48" src="https://user-images.githubusercontent.com/23151/92106305-7fc27c00-ede4-11ea-8743-2e50572fa8ad.png">

