### PR TITLE
Show affiliation for creators and contributors

### DIFF
--- a/cypress/fixtures/doi.json
+++ b/cypress/fixtures/doi.json
@@ -13,10 +13,25 @@
     "description": "Example description of the item."
   }],
   "creators": [{
+    "id": "https://orcid.org/0000-0003-3484-6875",
+    "name": "Smith, John",
+    "givenName": "John",
+    "familyName": "Smith",
+    "affiliation": [
+      { "id": "https://ror.org/04wxnsj81",
+        "name": "DataCite" }
+    ]
+  }],
+  "contributors": [{
     "id": null,
     "name": "Smith, John",
     "givenName": "John",
-    "familyName": "Smith"
+    "familyName": "Smith",
+    "contributorType": "Editor",
+    "affiliation": [
+      { "id": "https://ror.org/04wxnsj81",
+        "name": "DataCite" }
+    ]
   }],
   "publisher": "SURFsara",
   "publicationYear": 2019,

--- a/cypress/integration/workContainer.test.ts
+++ b/cypress/integration/workContainer.test.ts
@@ -1,47 +1,31 @@
-// describe('WorkContainer', () => {
-//   before(() => {
-//     cy.visit(`/doi.org/${encodeURIComponent('10.4224/crm.2012e.cass-5')}`)
-//   })
-
-//   it('visit 10.4224/crm.2012e.cass-5', () => {
-//     cy.get('h3.work', { timeout: 10000 })
-//       .contains(
-//         'CASS-5: Nearshore seawater reference material for trace metals'
-//       )
-//       .should('be.visible')
-//   })
-
-//   it('export box', () => {
-//     cy.get('div#export-xml', { timeout: 30000 })
-//       // timeout for the query results to return
-//       .contains('DataCite XML')
-//       .should('be.visible')
-//   })
-
-//   it('cite as', () => {
-//     cy.get('select.cite-as')
-//       .select('ieee')
-//       // timeout for the query results to return
-//       .get('.formatted-citation', { timeout: 30000 })
-//       .should('be.visible')
-//     //.contains('CXC-DS, “Chandra X-ray Observatory ObsId 1.”')
-//   })
-
-//   // it("chart", () => {
-//   //   cy.get('.mark-rect > path')
-//   //   .should('be.visible')
-//   //   .should('have.length', 4)
-//   // })
-// })
-
 describe('workContainer with usage', () => {
   before(() => {
     cy.setCookie('_consent', 'true')
     cy.visit(`/doi.org/${encodeURIComponent('10.70048/findable101')}`)
   })
 
+  it('creators', () => {
+    cy.get('.creator .creator-list', { timeout: 30000 })
+      .should('have.length', 1)
+      .should('contain', 'DataCite Metadata Working Group')
+  })
+
+  it('contributors', () => {
+    cy.get('.contributor .contributor-list', { timeout: 30000 })
+      .should('have.length', 6)
+      .should('contain', 'Joan Starr')
+  })
+
+  it('cite as', () => {
+    cy.get('select.cite-as')
+      .select('ieee')
+      .get('.formatted-citation', { timeout: 30000 })
+      .should('be.visible')
+      .should('contain', 'DataCite Metadata Schema Documentation for the Publication and Citation of Research Data v4.0.')
+  })
+
   it('chart', () => {
-    cy.get('.mark-rect > path', { timeout: 10000 })
+    cy.get('.mark-rect > path', { timeout: 30000 })
       .should('be.visible')
       .should('have.length', 4)
   })

--- a/hooks/withApollo.ts
+++ b/hooks/withApollo.ts
@@ -37,6 +37,16 @@ export default withApollo(({ initialState }) => {
           // Singleton types that have no identifying field can use an empty
           // array for their keyFields.
           keyFields: false
+        },
+        Contributor: {
+          // Singleton types that have no identifying field can use an empty
+          // array for their keyFields.
+          keyFields: false
+        },
+        Affiliation: {
+          // Singleton types that have no identifying field can use an empty
+          // array for their keyFields.
+          keyFields: false
         }
       }
     }).restore(initialState || {})

--- a/src/components/PersonEmployment/PersonEmployment.tsx
+++ b/src/components/PersonEmployment/PersonEmployment.tsx
@@ -11,17 +11,17 @@ type Props = {
 const PersonEmployment: React.FunctionComponent<Props> = ({ employment }) => {
   const name = () => {
     if (!employment.organizationId)
-      return <h3 className="work">{employment.organizationName}</h3>
+      return <h4 className="work">{employment.organizationName}</h4>
 
     return (
-      <h3 className="work">
+      <h4 className="work">
         <Link
           href="/grid.ac/[...organization]"
           as={`/grid.ac${gridFromUrl(employment.organizationId)}`}
         >
           <a>{employment.organizationName}</a>
         </Link>
-      </h3>
+      </h4>
     )
   }
 

--- a/src/components/SearchWork/SearchWork.tsx
+++ b/src/components/SearchWork/SearchWork.tsx
@@ -110,6 +110,10 @@ export const contentFragment = {
         name
         givenName
         familyName
+        affiliation {
+          id
+          name
+        }
       }
       descriptions {
         description

--- a/src/components/Work/Work.tsx
+++ b/src/components/Work/Work.tsx
@@ -309,7 +309,7 @@ const DoiPresentation: React.FunctionComponent<Props> = ({ doi }) => {
           <div className="panel panel-transparent contributor">
             <div className="panel-body">
               {chunk(doi.contributors, 3).map((row) => (
-                <Row className="creator-list" key={row[0].name}>
+                <Row className="contributor-list" key={row[0].name}>
                   {row.map((item) => (
                     <Col key={item.name} md={4}><WorkPerson person={item} /></Col>
                   ))}
@@ -328,7 +328,7 @@ const DoiPresentation: React.FunctionComponent<Props> = ({ doi }) => {
         <div className="panel panel-transparent contributor">
           <div className="panel-body">
             {chunk(doi.fundingReferences, 3).map((row) => (
-              <Row className="creator-list" key={row[0].funderName}>
+              <Row className="funder-list" key={row[0].funderName}>
                 {row.map((item) => (
                   <Col key={item.funderName} md={4}><WorkFunding funding={item} /></Col>
                 ))}

--- a/src/components/Work/Work.tsx
+++ b/src/components/Work/Work.tsx
@@ -11,11 +11,13 @@ import {
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faEnvelope } from '@fortawesome/free-solid-svg-icons'
 import { faTwitter, faFacebook } from '@fortawesome/free-brands-svg-icons'
+import chunk from 'lodash/chunk'
 
 import { WorkType } from '../WorkContainer/WorkContainer'
 import CitationFormatter from '../CitationFormatter/CitationFormatter'
 import WorkMetadata from '../WorkMetadata/WorkMetadata'
 import WorkFunding from '../WorkFunding/WorkFunding'
+import WorkPerson from '../WorkPerson/WorkPerson'
 import UsageChart from '../UsageChart/UsageChart'
 
 type Props = {
@@ -27,12 +29,11 @@ const DoiPresentation: React.FunctionComponent<Props> = ({ doi }) => {
   const showQrCode = useFeature('downloadLink')
   const downloadLink = useFeature('downloadLink')
   const [selectedOption, setSelectedOption] = React.useState('')
-  
+
   if (!doi) return <Alert bsStyle="warning">No works found.</Alert>
 
   const showFunding =
-    doi.fundingReferences &&
-    doi.fundingReferences.length > 0 && workFunding 
+    doi.fundingReferences && doi.fundingReferences.length > 0 && workFunding
 
   const shareLink = () => {
     const pageUrl =
@@ -282,23 +283,63 @@ const DoiPresentation: React.FunctionComponent<Props> = ({ doi }) => {
     <>
       <h3 className="member-results">{'https://doi.org/' + doi.doi}</h3>
       <WorkMetadata metadata={doi} linkToExternal={true}></WorkMetadata>
-      {exportMetadata()}
-      {shareLink()}
-      {formattedCitation()}
+      {doi.creators.length > 0 && (
+        <>
+          <h3 className="member-results" id="work-creators">
+            Creators
+          </h3>
+          <div className="panel panel-transparent creator">
+            <div className="panel-body">
+              {chunk(doi.creators, 3).map((row) => (
+                <Row className="creator-list" key={row[0].name}>
+                  {row.map((item) => (
+                    <Col key={item.name} md={4}><WorkPerson person={item} /></Col>
+                  ))}
+                </Row>
+              ))}
+            </div>
+          </div>
+        </>
+      )}
+      {doi.contributors.length > 0 && (
+        <>
+          <h3 className="member-results" id="work-contributors">
+            Contributors
+          </h3>
+          <div className="panel panel-transparent contributor">
+            <div className="panel-body">
+              {chunk(doi.contributors, 3).map((row) => (
+                <Row className="creator-list" key={row[0].name}>
+                  {row.map((item) => (
+                    <Col key={item.name} md={4}><WorkPerson person={item} /></Col>
+                  ))}
+                </Row>
+              ))}
+            </div>
+          </div>
+        </>
+      )}
       {showFunding && (
         <h3 className="member-results" id="work-funding">
           Funding
         </h3>
       )}
-      {showFunding &&
-        doi.fundingReferences.map((item) => (
-          <div
-            className="panel panel-transparent funding"
-            key={item.funderName}
-          >
-            <WorkFunding funding={item} />
+      {showFunding && (
+        <div className="panel panel-transparent contributor">
+          <div className="panel-body">
+            {chunk(doi.fundingReferences, 3).map((row) => (
+              <Row className="creator-list" key={row[0].funderName}>
+                {row.map((item) => (
+                  <Col key={item.funderName} md={4}><WorkFunding funding={item} /></Col>
+                ))}
+              </Row>
+            ))}
           </div>
-        ))}
+        </div>
+      )}
+      {exportMetadata()}
+      {shareLink()}
+      {formattedCitation()}
       {analyticsBar()}
     </>
   )

--- a/src/components/WorkContainer/WorkContainer.tsx
+++ b/src/components/WorkContainer/WorkContainer.tsx
@@ -30,6 +30,17 @@ export const DOI_GQL = gql`
     work(id: $id) {
       ...WorkFragment
       contentUrl
+      contributors {
+        id
+        givenName
+        familyName
+        name
+        contributorType
+        affiliation {
+          id
+          name
+        }
+      }
       fundingReferences {
         funderIdentifier
         funderIdentifierType
@@ -122,6 +133,7 @@ export interface WorkType {
   }
   registered?: Date
   formattedCitation?: string
+  contributors?: Contributor[]
   fundingReferences?: FundingReference[]
   citationCount?: number
   citations?: {
@@ -158,11 +170,26 @@ interface Facet {
   count: number
 }
 
-interface Creator {
+export interface Creator {
   id: string
   name: string
   givenName: string
   familyName: string
+  affiliation: Affiliation[]
+}
+
+interface Contributor {
+  id: string
+  name: string
+  givenName: string
+  familyName: string
+  contributorType: string
+  affiliation: Affiliation[]
+}
+
+interface Affiliation {
+  id: string
+  name: string
 }
 
 interface Title {

--- a/src/components/WorkFunding/WorkFunding.tsx
+++ b/src/components/WorkFunding/WorkFunding.tsx
@@ -15,17 +15,17 @@ const WorkFunding: React.FunctionComponent<Props> = ({ funding }) => {
       funding.funderIdentifier.startsWith('https://doi.org/10.13039')
     )
       return (
-        <h3 className="work">
+        <h4 className="work">
           <Link
             href="/doi.org/[...doi]"
             as={`/doi.org${doiFromUrl(funding.funderIdentifier)}`}
           >
             <a>{funding.funderName}</a>
           </Link>
-        </h3>
+        </h4>
       )
 
-    return <h3 className="work">{funding.funderName}</h3>
+    return <h4 className="work">{funding.funderName}</h4>
   }
 
   const hasAward = funding.awardTitle || funding.awardNumber || funding.awardUri
@@ -65,10 +65,10 @@ const WorkFunding: React.FunctionComponent<Props> = ({ funding }) => {
   }
 
   return (
-    <div className="panel-body">
+    <>
       {funding.funderName && funder()}
       {hasAward && award()}
-    </div>
+    </>
   )
 }
 

--- a/src/components/WorkPerson/WorkPerson.test.tsx
+++ b/src/components/WorkPerson/WorkPerson.test.tsx
@@ -1,0 +1,28 @@
+/// <reference types="cypress" />
+
+import React from 'react'
+import { mount } from 'cypress-react-unit-test'
+import WorkPerson from './WorkPerson'
+
+describe('WorkMetadata Component', () => {
+  let data
+
+  beforeEach(function () {
+    cy.fixture('doi.json').then((d) => {
+      data = d
+    })
+  })
+
+  it('creator', () => {
+    mount(<WorkPerson person={data.creators[0]} />)
+    cy.get('h4.work').contains('John Smith').should('be.visible')
+    cy.get('div.affiliation').contains('DataCite').should('be.visible')
+  })
+
+  it('contributor', () => {
+    mount(<WorkPerson person={data.contributors[0]} />)
+    cy.get('h4.work').contains('John Smith').should('be.visible')
+    cy.get('div.affiliation').contains('DataCite').should('be.visible')
+    cy.get('div.contributor-type').contains('Editor').should('be.visible')
+  })
+})

--- a/src/components/WorkPerson/WorkPerson.tsx
+++ b/src/components/WorkPerson/WorkPerson.tsx
@@ -41,7 +41,7 @@ const WorkPerson: React.FunctionComponent<Props> = ({ person }) => {
         </h4>
         {person.affiliation.length > 0 && (
           <>
-            <div class="affiliation">
+            <div className="affiliation">
               {person.affiliation.map((item) =>
                 item.id ? (
                   <Link
@@ -78,7 +78,7 @@ const WorkPerson: React.FunctionComponent<Props> = ({ person }) => {
         </h4>
         {person.affiliation.length > 0 && (
           <>
-            <div class="affiliation">
+            <div className="affiliation">
               {person.affiliation.map((item) =>
                 item.id ? (
                   <Link
@@ -107,7 +107,7 @@ const WorkPerson: React.FunctionComponent<Props> = ({ person }) => {
       <h4 className="work">{name}</h4>
       {person.affiliation.length > 0 && (
         <>
-          <div class="affiliation">
+          <div className="affiliation">
             {person.affiliation.map((item) =>
               item.id ? (
                 <Link

--- a/src/components/WorkPerson/WorkPerson.tsx
+++ b/src/components/WorkPerson/WorkPerson.tsx
@@ -23,7 +23,7 @@ type Props = {
   person: Person
 }
 
-const WorkContributor: React.FunctionComponent<Props> = ({ person }) => {
+const WorkPerson: React.FunctionComponent<Props> = ({ person }) => {
   const name = person.familyName
     ? [person.givenName, person.familyName].join(' ')
     : person.name
@@ -41,7 +41,7 @@ const WorkContributor: React.FunctionComponent<Props> = ({ person }) => {
         </h4>
         {person.affiliation.length > 0 && (
           <>
-            <div>
+            <div class="affiliation">
               {person.affiliation.map((item) =>
                 item.id ? (
                   <Link
@@ -78,7 +78,7 @@ const WorkContributor: React.FunctionComponent<Props> = ({ person }) => {
         </h4>
         {person.affiliation.length > 0 && (
           <>
-            <div>
+            <div class="affiliation">
               {person.affiliation.map((item) =>
                 item.id ? (
                   <Link
@@ -107,7 +107,7 @@ const WorkContributor: React.FunctionComponent<Props> = ({ person }) => {
       <h4 className="work">{name}</h4>
       {person.affiliation.length > 0 && (
         <>
-          <div>
+          <div class="affiliation">
             {person.affiliation.map((item) =>
               item.id ? (
                 <Link
@@ -132,4 +132,4 @@ const WorkContributor: React.FunctionComponent<Props> = ({ person }) => {
   )
 }
 
-export default WorkContributor
+export default WorkPerson

--- a/src/components/WorkPerson/WorkPerson.tsx
+++ b/src/components/WorkPerson/WorkPerson.tsx
@@ -1,0 +1,135 @@
+import React from 'react'
+import Link from 'next/link'
+import startCase from 'lodash/startCase'
+
+import { orcidFromUrl } from '../../utils/helpers'
+import { rorFromUrl } from '../../utils/helpers'
+
+interface Person {
+  id: string
+  name: string
+  givenName?: string
+  familyName?: string
+  contributorType?: string
+  affiliation?: Affiliation[]
+}
+
+interface Affiliation {
+  id: string
+  name: string
+}
+
+type Props = {
+  person: Person
+}
+
+const WorkContributor: React.FunctionComponent<Props> = ({ person }) => {
+  const name = person.familyName
+    ? [person.givenName, person.familyName].join(' ')
+    : person.name
+
+  if (person.id && person.id.startsWith('https://orcid.org'))
+    return (
+      <>
+        <h4 className="work">
+          <Link
+            href="/orcid.org/[person]"
+            as={`/orcid.org${orcidFromUrl(person.id)}`}
+          >
+            <a>{name}</a>
+          </Link>
+        </h4>
+        {person.affiliation.length > 0 && (
+          <>
+            <div>
+              {person.affiliation.map((item) =>
+                item.id ? (
+                  <Link
+                    href="/ror.org/[organization]"
+                    as={`/ror.org${rorFromUrl(item.id)}`}
+                  >
+                    <a>{item.name}</a>
+                  </Link>
+                ) : (
+                  <div key={item.name}>{item.name}</div>
+                )
+              )}
+            </div>
+          </>
+        )}
+        {person.contributorType && (
+          <div className="contributor-type">
+            {startCase(person.contributorType)}
+          </div>
+        )}
+      </>
+    )
+
+  if (person.id && person.id.startsWith('https://ror.org'))
+    return (
+      <>
+        <h4 className="work">
+          <Link
+            href="/ror.org/[organization]"
+            as={`/ror.org${rorFromUrl(person.id)}`}
+          >
+            <a>{name}</a>
+          </Link>
+        </h4>
+        {person.affiliation.length > 0 && (
+          <>
+            <div>
+              {person.affiliation.map((item) =>
+                item.id ? (
+                  <Link
+                    href="/ror.org/[organization]"
+                    as={`/ror.org${rorFromUrl(item.id)}`}
+                  >
+                    <a>{item.name}</a>
+                  </Link>
+                ) : (
+                  <div key={item.name}>{item.name}</div>
+                )
+              )}
+            </div>
+          </>
+        )}
+        {person.contributorType && (
+          <div className="contributor-type">
+            {startCase(person.contributorType)}
+          </div>
+        )}
+      </>
+    )
+
+  return (
+    <>
+      <h4 className="work">{name}</h4>
+      {person.affiliation.length > 0 && (
+        <>
+          <div>
+            {person.affiliation.map((item) =>
+              item.id ? (
+                <Link
+                  href="/ror.org/[organization]"
+                  as={`/ror.org${rorFromUrl(item.id)}`}
+                >
+                  <a>{item.name}</a>
+                </Link>
+              ) : (
+                <div key={item.name}>{item.name}</div>
+              )
+            )}
+          </div>
+        </>
+      )}
+      {person.contributorType && (
+        <div className="contributor-type">
+          {startCase(person.contributorType)}
+        </div>
+      )}
+    </>
+  )
+}
+
+export default WorkContributor

--- a/src/styles.css
+++ b/src/styles.css
@@ -390,3 +390,11 @@ footer .funding {
 .registered span, .metrics span {
   font-size: inherit;
 }
+
+h4.work {
+  margin-bottom: 0;
+}
+
+.creator-list {
+  margin-bottom: 10px;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,5 +28,5 @@
     "next-env.d.ts",
     "**/*.ts",
     "**/*.tsx"
-  ]
+, "src/pages/overviewtsx"  ]
 }


### PR DESCRIPTION
## Purpose
Show additional information about people per DOI: contributors and affiliations.

closes:  #128

## Approach
Add new sections for creators and contributors in tabular format. This also helps with ORCID claiming, as we can link the claim to a specific author. To avoid long lists of creators, contributers (and funding), we arrange them in three columns.

## Types of changes

- [ ] New feature (non-breaking change which adds functionality)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
