### PR TITLE
'Staff' link has transitioned to 'Team' in most footers

### DIFF
--- a/config/links.yml
+++ b/config/links.yml
@@ -7,8 +7,8 @@ about_links:
    url: /members.html
  - name: Steering groups
    url: /steering.html
- - name: Staff
-   url: /staff.html
+ - name: Team
+   url: /team.html
  - name: Job opportunities
    url: /jobopportunities.html
 services_links:

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -19,7 +19,7 @@ const Links = {
     { name: 'Governance', url: '/governance.html' },
     { name: 'Members', url: '/members.html' },
     { name: 'Steering groups', url: '/steering.html' },
-    { name: 'Staff', url: '/staff.html' },
+    { name: 'Team', url: '/team.html' },
     { name: 'Job opportunities', url: '/jobopportunities.html' }
   ],
   services_links: [


### PR DESCRIPTION
## Purpose
DataCite footer link for "staff" transitioned to 'team' some time ago. Catching this app up.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
