### PR TITLE
Needed to specify font-awesome-common-types in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,5 +104,8 @@
     "tsify": "^4.0.2",
     "typescript": "^4.3.2"
   },
+  "resolutions": {
+    "**/@fortawesome/fontawesome-common-types": "^0.3.0"
+  },
   "license": "MIT"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1186,12 +1186,7 @@
     "@formatjs/intl-localematcher" "0.2.24"
     tslib "^2.1.0"
 
-"@fortawesome/fontawesome-common-types@^0.2.36":
-  version "0.2.36"
-  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.36.tgz#b44e52db3b6b20523e0c57ef8c42d315532cb903"
-  integrity sha512-a/7BiSgobHAgBWeN7N0w+lAhInrGxksn13uK7231n2m8EDPE3BMCl9NZLTGrj9ZXfCmC6LM0QLqXidIizVQ6yg==
-
-"@fortawesome/fontawesome-common-types@^0.3.0":
+"@fortawesome/fontawesome-common-types@^0.2.36", "@fortawesome/fontawesome-common-types@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.3.0.tgz#949995a05c0d8801be7e0a594f775f1dbaa0d893"
   integrity sha512-CA3MAZBTxVsF6SkfkHXDerkhcQs0QPofy43eFdbWJJkZiq3SfiaH1msOkac59rQaqto5EqWnASboY1dBuKen5w==


### PR DESCRIPTION
## Purpose
There was an error on deployment to vercel with regards to font-awesome and react.
Specifically 'IconDefinition' is not assignable to type 'IconProp'
## Learning

[Type 'IconDefinition' is not assignable to type 'IconProp' with Typescript](https://github.com/FortAwesome/react-fontawesome/issues/366#)

As outlined in the above link, we had two versions of font-awesome-common-types that were in conflict with eachother.

Specify the resolution of font-awesome-common-types in package.json should fix this.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
