### PR TITLE
Remove explicit <string> typecast from useQueryState as that is the d…

### DIFF
--- a/src/components/FilterItem/FilterItem.tsx
+++ b/src/components/FilterItem/FilterItem.tsx
@@ -16,7 +16,7 @@ const FilterItem: React.FunctionComponent<Props> = ({
   title,
   count
 }) => {
-  const [activeFilter, setActiveFilter] = useQueryState<string>(name)
+  const [activeFilter, setActiveFilter] = useQueryState(name)
 
   const activeIcon = (fid: string) => {
     let icon = faSquare

--- a/src/components/SearchOrganization/SearchOrganization.tsx
+++ b/src/components/SearchOrganization/SearchOrganization.tsx
@@ -127,8 +127,8 @@ const SearchOrganizations: React.FunctionComponent<Props> = ({
   searchQuery
 }) => {
   const [cursor] = useQueryState('cursor', { history: 'push' })
-  const [types] = useQueryState<string>('types')
-  const [country] = useQueryState<string>('country')
+  const [types] = useQueryState('types')
+  const [country] = useQueryState('country')
 
   const { loading, error, data } = useQuery<
     OrganizationsQueryData,

--- a/src/components/SearchRepository/SearchRepository.tsx
+++ b/src/components/SearchRepository/SearchRepository.tsx
@@ -71,8 +71,8 @@ const SearchRepositories: React.FunctionComponent<Props> = ({
   searchQuery
 }) => {
   const [cursor] = useQueryState('cursor', { history: 'push' })
-  const [certificate] = useQueryState<string>('certificate')
-  const [software] = useQueryState<string>('software')
+  const [certificate] = useQueryState('certificate')
+  const [software] = useQueryState('software')
   const { loading, error, data } = useQuery<
     RepositoriesQueryData, RepositoriesQueryVar
   >(REPOSITORIES_GQL, {

--- a/src/pages/doi.org/[...doi].tsx
+++ b/src/pages/doi.org/[...doi].tsx
@@ -430,7 +430,7 @@ const WorkPage: React.FunctionComponent<Props> = ({ doi, metadata }) => {
   )
     type = metadata.work.types.resourceType.toLowerCase()
 
-  const [filterQuery] = useQueryState<string>('filterQuery')
+  const [filterQuery] = useQueryState('filterQuery')
   const [cursor] = useQueryState('cursor', { history: 'push' })
   const [published] = useQueryState('published', { history: 'push' })
   const [resourceType] = useQueryState('resource-type', { history: 'push' })

--- a/src/pages/doi.org/index.tsx
+++ b/src/pages/doi.org/index.tsx
@@ -6,7 +6,7 @@ import Teaser from '../../components/Teaser/Teaser'
 import SearchWork from '../../components/SearchWork/SearchWork'
 
 const IndexPage = () => {
-  const [searchQuery] = useQueryState<string>('query')
+  const [searchQuery] = useQueryState('query')
 
   return (
     <Layout path={'/doi.org'} >

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -6,7 +6,7 @@ import Teaser from '../components/Teaser/Teaser'
 import SearchWork from '../components/SearchWork/SearchWork'
 
 const IndexPage = () => {
-  const [searchQuery] = useQueryState<string>('query')
+  const [searchQuery] = useQueryState('query')
 
   return (
     <Layout path={'/doi.org'} >

--- a/src/pages/orcid.org/[orcid].tsx
+++ b/src/pages/orcid.org/[orcid].tsx
@@ -186,7 +186,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 }
 
 const PersonPage: React.FunctionComponent<Props> = ({ orcid }) => {
-  const [filterQuery] = useQueryState<string>('filterQuery')
+  const [filterQuery] = useQueryState('filterQuery')
   const [cursor] = useQueryState('cursor', { history: 'push' })
   const [published] = useQueryState('published', {
     history: 'push'

--- a/src/pages/orcid.org/index.tsx
+++ b/src/pages/orcid.org/index.tsx
@@ -6,7 +6,7 @@ import Teaser from '../../components/Teaser/Teaser'
 import SearchPerson from '../../components/SearchPerson/SearchPerson'
 
 const IndexPersonPage = () => {
-  const [searchQuery] = useQueryState<string>('query')
+  const [searchQuery] = useQueryState('query')
   
   return (
     <Layout path={'/orcid.org'} >

--- a/src/pages/repositories/index.tsx
+++ b/src/pages/repositories/index.tsx
@@ -7,7 +7,7 @@ import Layout from '../../components/Layout/Layout'
 import SearchRepository from '../../components/SearchRepository/SearchRepository'
 
 const RepositoryIndexPage = () => {
-  const [searchQuery] = useQueryState<string>('query')
+  const [searchQuery] = useQueryState('query')
 
   return (
     <Layout path={'/repositories'}>

--- a/src/pages/ror.org/[rorid].tsx
+++ b/src/pages/ror.org/[rorid].tsx
@@ -153,7 +153,7 @@ const OrganizationPage: React.FunctionComponent<Props> = ({
   crossrefFunderId
 }) => {
   const router = useRouter()
-  const [filterQuery] = useQueryState<string>('filterQuery')
+  const [filterQuery] = useQueryState('filterQuery')
   const [published] = useQueryState('published', {
     history: 'push'
   })

--- a/src/pages/ror.org/index.tsx
+++ b/src/pages/ror.org/index.tsx
@@ -6,7 +6,7 @@ import Layout from '../../components/Layout/Layout'
 import SearchOrganization from '../../components/SearchOrganization/SearchOrganization'
 
 const OrganizationIndexPage = () => {
-  const [searchQuery] = useQueryState<string>('query')
+  const [searchQuery] = useQueryState('query')
 
   return (
     <Layout path={'/ror.org'}>


### PR DESCRIPTION
…efault

## Purpose
`next build` threw some errors after a dependency update.
These were not picked up in dev or tests since they do not go through the full build process.


closes: _Add github issue that originated this PR_

## Approach and Learning
I opened an issue on the library maintainers repository and they had some suggestions.

https://github.com/47ng/next-usequerystate/issues/289

Remove explicit <string> typecast from useQueryState
It throws the compiler off-course in finding the right overload to use.

This worked

Also, make sure to run `yarn build` before committing.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
