### PR TITLE
Display GridID only if it exists in metadata

### DIFF
--- a/cypress/integration/OrganizationContainerMissingGridID.test.ts
+++ b/cypress/integration/OrganizationContainerMissingGridID.test.ts
@@ -1,0 +1,19 @@
+describe('OrganizationContainer Display GridID if it exists', () => {
+  beforeEach(() => {
+    cy.setCookie('_consent', 'true')
+  })
+  it('visit site with gridID, id element should exist', () => {
+    cy.visit('/ror.org/052gg0110')
+    cy
+      .get('.identifier').first()
+      .should('include.text','GRID')
+  })
+  it('visit site without gridID, id element not should exist', () => {
+    cy.visit('ror.org/02hhf2525')
+    cy
+      .get('.identifier')
+      .should('not.include.text','GRID')
+  })
+})
+
+export {}

--- a/cypress/integration/OrganizationContainerMissingGridID.test.ts
+++ b/cypress/integration/OrganizationContainerMissingGridID.test.ts
@@ -9,7 +9,7 @@ describe('OrganizationContainer Display GridID if it exists', () => {
       .should('include.text','GRID')
   })
   it('visit site without gridID, id element not should exist', () => {
-    cy.visit('ror.org/02hhf2525')
+    cy.visit('/ror.org/02hhf2525')
     cy
       .get('.identifier')
       .should('not.include.text','GRID')

--- a/src/components/OrganizationMetadata/OrganizationMetadata.tsx
+++ b/src/components/OrganizationMetadata/OrganizationMetadata.tsx
@@ -155,24 +155,26 @@ export const OrganizationMetadata: React.FunctionComponent<Props> = ({
           </Col>
           <Col xs={6} md={6}>
             <h5>Other Identifiers</h5>
-            <div>
-              GRID{' '}
-              <a
-                target="_blank"
-                rel="noreferrer"
-                href={
-                  'https://grid.ac/institutes/' + grid[0].identifier
-                }
-              >
-                {grid[0].identifier}
-              </a>
-            </div>
+            {grid.length > 0 && (
+              <div className="identifier id-type-grid">
+                GRID{' '}
+                <a
+                  target="_blank"
+                  rel="noreferrer"
+                  href={
+                    'https://grid.ac/institutes/' + grid[0].identifier
+                  }
+                >
+                  {grid[0].identifier}
+                </a>
+              </div>
+            )}
             {fundref.length > 0 && (
               <>
                 {fundref
                   .filter((_, idx) => idx < 5)
                   .map((id) => (
-                    <div key={id.identifier}>
+                    <div key={id.identifier} className="identifier id-type-crossref-funder">
                       Crossref Funder ID{' '}
                       <a
                         target="_blank"
@@ -190,7 +192,7 @@ export const OrganizationMetadata: React.FunctionComponent<Props> = ({
                 {isni
                   .filter((_, idx) => idx < 5)
                   .map((id) => (
-                    <div key={id.identifier}>
+                    <div key={id.identifier} className="identifier id-type-isni">
                       ISNI{' '}
                       <a
                         target="_blank"
@@ -208,7 +210,7 @@ export const OrganizationMetadata: React.FunctionComponent<Props> = ({
                 {wikidata
                   .filter((_, idx) => idx < 5)
                   .map((id) => (
-                    <div key={id.identifier}>
+                    <div key={id.identifier} className="identifier id-type-wikidata">
                       Wikidata{' '}
                       <a
                         target="_blank"


### PR DESCRIPTION
## Purpose
Fix a bug where the GridID was assumed to exists.  Handles the case where it does not.

closes: #213

## Approach
Wraps checks that the array of grid ids is larger than 0 before trying to render a link to a grid identifier.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
