### PR TITLE
Consisten button UI in Commons

### DIFF
--- a/src/components/Claim/Claim.tsx
+++ b/src/components/Claim/Claim.tsx
@@ -166,10 +166,25 @@ const Claim: React.FunctionComponent<Props> = ({ doi_id }) => {
   // don't show claim option if registration agency is not datacite
   const user = session()
   if (
-    !user ||
     (data.work.registrationAgency && data.work.registrationAgency.id !== 'datacite')
   )
     return null
+
+  if (!user){
+    return (
+      <>
+      <h3 className="member-results">ORCID Claim</h3>
+      <div className="panel panel-transparent claim"></div>
+      <div className="panel-body">
+        <Row>
+            <Col xs={6} md={4}>
+              <Button bsStyle={'btn-default'} disabled title="Sign in to Add to ORCID record">Claim DOI</Button>
+            </Col>
+        </Row>
+      </div>
+    </>
+    )
+  }
 
   const claim: ClaimType = data.work.claims[0] || {
     id: null,

--- a/src/components/Claim/Claim.tsx
+++ b/src/components/Claim/Claim.tsx
@@ -225,8 +225,7 @@ const Claim: React.FunctionComponent<Props> = ({ doi_id }) => {
                   </Button>
                   :
                   <Button
-                    bsStyle={'info'}
-                    className="claim"
+                    bsStyle={'btn-default'}
                     onClick={onCreate}
                   >
                     <FontAwesomeIcon icon={faOrcid} /> Claim DOI


### PR DESCRIPTION
## Purpose
The color of the claim button is that of a info-label while the rest of fabrica uses 'defaul-label' for this buttons (secondary)


## Approach

Change the class.


#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
