### PR TITLE
Unique keys

### DIFF
--- a/src/components/FacetList/FacetList.tsx
+++ b/src/components/FacetList/FacetList.tsx
@@ -35,8 +35,8 @@ export const FacetList: React.FunctionComponent<Props> = ({
           <div className="panel-body">
             <h4>{title}</h4>
             <ul>
-              {facets.map((facet) => (
-                  <li key={facet.id}>
+              {facets.map((facet, index) => (
+                  <li key={`facet-${name}-${facet.id}-${index}`}>
                     <FilterItem
                       name={name}
                       id={facet.id}

--- a/src/components/FairFilter/FairFilter.tsx
+++ b/src/components/FairFilter/FairFilter.tsx
@@ -16,7 +16,8 @@ const FairFilter: React.FunctionComponent<Props> = () => {
     const [fairCriterias, setFairCriteria] = useQueryStates({
         hasPid: queryTypes.string.withDefault(''),
         isOpen: queryTypes.string.withDefault(''),
-        subjectId: queryTypes.string.withDefault('')
+        subjectId: queryTypes.string.withDefault(''),
+        isCertified: queryTypes.string.withDefault('')
     })
 
     const tooltipFAIRfilters = (
@@ -59,6 +60,7 @@ const FairFilter: React.FunctionComponent<Props> = () => {
                 setFairCriteria({
                     hasPid: "true",
                     isOpen: "true",
+                    isCertified: null,
                     subjectId: "34"
                 })
                 break;
@@ -66,6 +68,7 @@ const FairFilter: React.FunctionComponent<Props> = () => {
                 setFairCriteria({
                     hasPid: "true",
                     isOpen: "true",
+                    isCertified: "true",
                     subjectId: null
                 })
                 break;
@@ -74,6 +77,7 @@ const FairFilter: React.FunctionComponent<Props> = () => {
             setFairCriteria({
                 hasPid: null,
                 isOpen: null,
+                isCertified: null,
                 subjectId: null
             })
         }

--- a/src/components/RepositoryDetail/RepositoryDetail.tsx
+++ b/src/components/RepositoryDetail/RepositoryDetail.tsx
@@ -168,7 +168,7 @@ export const RepositorySidebar: React.FunctionComponent<Props> = ({
 
     return (
       <>
-      { (repo.contact) && (
+        { (repo.contact?.length > 0) && (
         <>
         <h3>Contacts</h3>
         { contactsData.map((contact, index) => (
@@ -364,13 +364,13 @@ export const RepositoryDetail: React.FunctionComponent<Props> = ({
       }
     ];
 
-    const metricList = metricsData.map( (metric) => 
+    const metricList = metricsData.map( (metric, index) => 
     <>
       {metric.count>0 &&(
-        <>
+        <React.Fragment key={"metric-"+index}>
           <dt>{metric.label}</dt>
           <dd>{compactNumbers(metric.count)}</dd>
-        </>
+        </React.Fragment >
       )}
       </>
     )

--- a/src/components/SearchRepository/SearchRepository.tsx
+++ b/src/components/SearchRepository/SearchRepository.tsx
@@ -30,6 +30,7 @@ interface RepositoriesQueryVar {
   software: string
   hasPid: string
   isOpen: string
+  isCertified: string
   subjectId: string
 }
 
@@ -54,6 +55,7 @@ export const REPOSITORIES_GQL = gql`
     $software: String
     $hasPid: String
     $isOpen: String
+    $isCertified: String
     $subjectId: String
   ) {
     repositories(
@@ -63,6 +65,7 @@ export const REPOSITORIES_GQL = gql`
       software: $software
       hasPid: $hasPid
       isOpen: $isOpen
+      isCertified: $isCertified
       subjectId: $subjectId
     ) {
       totalCount
@@ -85,6 +88,7 @@ const SearchRepositories: React.FunctionComponent<Props> = ({
   const [software] = useQueryState('software')
   const [hasPid] = useQueryState('hasPid')
   const [isOpen] = useQueryState('isOpen')
+  const [isCertified] = useQueryState('isCertified')
   const [subjectId] = useQueryState('subjectId')
   const { loading, error, data } = useQuery<
     RepositoriesQueryData, RepositoriesQueryVar
@@ -97,6 +101,7 @@ const SearchRepositories: React.FunctionComponent<Props> = ({
       software: software,
       hasPid: hasPid,
       isOpen: isOpen,
+      isCertified: isCertified,
       subjectId: subjectId,
     }
 })

--- a/src/utils/apolloClient.ts
+++ b/src/utils/apolloClient.ts
@@ -46,6 +46,9 @@ const apolloClient = new ApolloClient({
         // Singleton types that have no identifying field can use an empty
         // array for their keyFields.
         keyFields: false
+      },
+      Facet: {
+        keyFields: false
       }
     }
   })


### PR DESCRIPTION
## Purpose
Facets in repository search were showing some strange behavior.  Many were displaying the same values when they should not.
This PR fixes that by configuring the Apollo client to not cache facets.

Also, the conditional display of contacts was not working in the repository display.
This was because in JavaScript, an empty array is a truethy value.  The solution is to query if `dataArray?.lenth>0`


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
