### PR TITLE
Move next/head tag into RepositoryHeadInfo

### DIFF
--- a/src/components/RepositoryDetail/RepositoryDetail.tsx
+++ b/src/components/RepositoryDetail/RepositoryDetail.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import Link from 'next/link'
+import Head from 'next/head'
 import { Button, Label } from 'react-bootstrap';
 import { gql } from '@apollo/client'
 import {FACET_FIELDS, Facet} from '../FacetList/FacetList'
@@ -116,18 +117,18 @@ const pageInfo = (repo) => {
   }
 }
 
-export const RepositoryHeaderInfo: React.FunctionComponent<Props> = ({
+export const RepositoryHeadInfo: React.FunctionComponent<Props> = ({
   repo
 }) => {
     const info = pageInfo(repo);
     return (
-      <>
+      <Head>
           <title>{info.title}</title>
           <meta name="og:title" content={info.title} />
           <meta name="og:url" content={info.pageUrl} />
           <meta name="og:image" content={info.imageUrl} />
           <meta name="og:type" content="organization" />
-      </>
+      </Head>
     )
 
   }

--- a/src/pages/repositories/[repoid].tsx
+++ b/src/pages/repositories/[repoid].tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import { gql, useQuery } from '@apollo/client'
 import { GetServerSideProps } from 'next'
 import Error from '../../components/Error/Error'
-import Head from 'next/head'
 import Layout from '../../components/Layout/Layout'
 import Loading from '../../components/Loading/Loading'
 import { Row, Col } from 'react-bootstrap'
@@ -10,7 +9,7 @@ import {
   REPOSITORY_DETAIL_FIELDS,
   RepositoryDetailNode,
   RepositorySidebar,
-  RepositoryHeaderInfo,
+  RepositoryHeadInfo,
   RepositoryDetail
 } from '../../components/RepositoryDetail/RepositoryDetail'
 
@@ -61,9 +60,7 @@ const RepositoryDetalPage: React.FunctionComponent<Props> = ({
           <>
             {error? <Error title="An error occured." message={error.message} />:(
               <>
-                <Head>
-                  <RepositoryHeaderInfo repo={data.repository}/>
-                </Head>
+                <RepositoryHeadInfo repo={data.repository}/>
                 <Row>
                   <Col md={3}>
                     <RepositorySidebar repo={data.repository}/>


### PR DESCRIPTION
## Purpose
OpenGraphTags and title were not rendering in the <head> element for repository detail pages.

closes: #228 

## Approach
The title and meta tags must be direct children of the next/head tag.  Moved the next/head tag into the RepositoryHeadInfo tag.

## Learning
https://nextjs.org/docs/api-reference/next/head


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
