### PR TITLE
Fair visualizations feature 5 - Action Left Bar Menu

### DIFF
--- a/cypress/integration/searchWork.test.ts
+++ b/cypress/integration/searchWork.test.ts
@@ -25,7 +25,7 @@ describe('Search Works', () => {
       .get('.panel.facets.add')
       .should(($facet) => {
         expect($facet).to.have.length.at.least(4)
-        expect($facet.eq(0)).to.contain('Authors & Contributors')
+        expect($facet.eq(0)).to.contain('Authors')
         expect($facet.eq(1)).to.contain('Publication Year')
         expect($facet.eq(2)).to.contain('Work Type')
         expect($facet.eq(3)).to.contain('License')

--- a/src/components/MetadataTable/MetadataTable.tsx
+++ b/src/components/MetadataTable/MetadataTable.tsx
@@ -136,7 +136,7 @@ export const MetadataTable: React.FunctionComponent<Props> = ({ metadata }) => {
           )}{' '}
           via {metadata.registrationAgency.name}
         </div>
-      </div>.
+      </div>
     </Tab>
   }
 
@@ -153,11 +153,15 @@ export const MetadataTable: React.FunctionComponent<Props> = ({ metadata }) => {
   }
   
   return (
-    <div className={styles.container + ' nav-tabs-member'}>
-      <Tabs className="content-tabs">
-        {METADATA_TYPES.map((type, index) => tab(type, index)
-        )}
-      </Tabs>
+    <div className="panel panel-transparent">
+      <div className="panel-body">
+        <div className={styles.container + ' nav-tabs-member'}>
+          <Tabs className="content-tabs">
+            {METADATA_TYPES.map((type, index) => tab(type, index)
+            )}
+          </Tabs>
+        </div>
+      </div>
     </div>
   )
 }

--- a/src/components/Organization/Organization.tsx
+++ b/src/components/Organization/Organization.tsx
@@ -1,16 +1,6 @@
 import React from 'react'
-import { Row, Col } from 'react-bootstrap'
-import {
-  EmailShareButton,
-  FacebookShareButton,
-  TwitterShareButton
-} from 'react-share'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faEnvelope } from '@fortawesome/free-solid-svg-icons'
-import { faTwitter, faFacebook } from '@fortawesome/free-brands-svg-icons'
 
 import OrganizationMetadata from '../OrganizationMetadata/OrganizationMetadata'
-import { rorFromUrl } from '../../utils/helpers'
 import { Works } from '../SearchWork/SearchWork'
 import { MetricsDisplay } from '../MetricsDisplay/MetricsDisplay'
 
@@ -50,45 +40,6 @@ type Props = {
 const Organization: React.FunctionComponent<Props> = ({
   organization
 }) => {
-  const pageUrl =
-    process.env.NEXT_PUBLIC_API_URL === 'https://api.datacite.org'
-      ? 'https://commons.datacite.org/ror.org' + rorFromUrl(organization.id)
-      : 'https://commons.stage.datacite.org/ror.org' + rorFromUrl(organization.id)
-
-  const title = organization.name
-    ? 'DataCite Commons: ' + organization.name
-    : 'DataCite Commons: No Name'
-
-  const shareLink = () => {
-    return (
-      <>
-        <h3 className="member-results">Share</h3>
-        <div className="panel panel-transparent">
-          <div className="panel-body">
-            <Row>
-              <Col xs={6} md={4}>
-                <div>
-                  <EmailShareButton url={pageUrl} title={title}>
-                    <FontAwesomeIcon icon={faEnvelope} /> Email
-                  </EmailShareButton>
-                </div>
-                <div>
-                  <TwitterShareButton url={pageUrl} title={title}>
-                    <FontAwesomeIcon icon={faTwitter} /> Twitter
-                  </TwitterShareButton>
-                </div>
-                <div>
-                  <FacebookShareButton url={pageUrl} title={title}>
-                    <FontAwesomeIcon icon={faFacebook} /> Facebook
-                  </FacebookShareButton>
-                </div>
-              </Col>
-            </Row>
-          </div>
-        </div>
-      </>
-    )
-  }
 
   return (
     <>
@@ -110,7 +61,6 @@ const Organization: React.FunctionComponent<Props> = ({
         </div>
       </div>
       <OrganizationMetadata metadata={organization} showTitle={false} />
-      {shareLink()}
     </>
   )
 }

--- a/src/components/Person/Person.tsx
+++ b/src/components/Person/Person.tsx
@@ -8,7 +8,7 @@ import { Alert, Row, Col } from 'react-bootstrap'
 import { WorkType } from '../../pages/doi.org/[...doi]'
 import PersonMetadata from '../PersonMetadata/PersonMetadata'
 import PersonEmployment from '../PersonEmployment/PersonEmployment'
-import { pluralize, orcidFromUrl } from '../../utils/helpers'
+import { pluralize } from '../../utils/helpers'
 
 export interface PersonRecord {
   id: string

--- a/src/components/Person/Person.tsx
+++ b/src/components/Person/Person.tsx
@@ -4,14 +4,6 @@ import heroImage from '../../../public/images/hero.svg'
 import unlockImage from '../../../public/images/unlock.svg'
 import scienceImage from '../../../public/images/science.svg'
 import { Alert, Row, Col } from 'react-bootstrap'
-import {
-  EmailShareButton,
-  FacebookShareButton,
-  TwitterShareButton
-} from 'react-share'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faEnvelope } from '@fortawesome/free-solid-svg-icons'
-import { faTwitter, faFacebook } from '@fortawesome/free-brands-svg-icons'
 
 import { WorkType } from '../../pages/doi.org/[...doi]'
 import PersonMetadata from '../PersonMetadata/PersonMetadata'
@@ -91,15 +83,6 @@ type Props = {
 const Person: React.FunctionComponent<Props> = ({ person }) => {
   if (!person) return <Alert bsStyle="warning">No person found.</Alert>
 
-  const pageUrl =
-    process.env.NEXT_PUBLIC_API_URL === 'https://api.datacite.org'
-      ? 'https://commons.datacite.org/orcid.org' + orcidFromUrl(person.id)
-      : 'https://commons.stage.datacite.org/orcid.org' + orcidFromUrl(person.id)
-
-  const title = person.name
-    ? 'DataCite Commons: ' + person.name
-    : 'DataCite Commons: No Name'
-
   let has_open_access_software = false;
   let has_open_access_paper = false;
   let has_open_access_dataset = false;
@@ -128,37 +111,6 @@ const Person: React.FunctionComponent<Props> = ({ person }) => {
 
   const percentage_open_license = Math.round((open_license_count / person.totalWorks.totalCount) * 100)
   const percentage_open_url = Math.round((person.totalWorks.totalContentUrl / person.totalWorks.totalCount) * 100)
-
-  const shareLink = () => {
-    return (
-      <>
-        <h3 className="member-results">Share</h3>
-        <div className="panel panel-transparent">
-          <div className="panel-body">
-            <Row>
-              <Col xs={6} md={4}>
-                <div>
-                  <EmailShareButton url={pageUrl} title={title}>
-                    <FontAwesomeIcon icon={faEnvelope} /> Email
-                  </EmailShareButton>
-                </div>
-                <div>
-                  <TwitterShareButton url={pageUrl} title={title}>
-                    <FontAwesomeIcon icon={faTwitter} /> Twitter
-                  </TwitterShareButton>
-                </div>
-                <div>
-                  <FacebookShareButton url={pageUrl} title={title}>
-                    <FontAwesomeIcon icon={faFacebook} /> Facebook
-                  </FacebookShareButton>
-                </div>
-              </Col>
-            </Row>
-          </div>
-        </div>
-      </>
-    )
-  }
 
   const workCount = () => {
     if (person.citationCount + person.viewCount + person.downloadCount === 0) {
@@ -273,7 +225,6 @@ const Person: React.FunctionComponent<Props> = ({ person }) => {
     <>
       <h3 className="member-results">{person.id}</h3>
       <PersonMetadata metadata={person} />
-      {shareLink()}
       {person.employment.length > 0 && (
         <h3 className="member-results" id="person-employment">Employment</h3>
       )}

--- a/src/components/RepositoryDetail/RepositoryDetail.tsx
+++ b/src/components/RepositoryDetail/RepositoryDetail.tsx
@@ -7,13 +7,7 @@ import {FACET_FIELDS, Facet} from '../FacetList/FacetList'
 import VerticalBarChart from '../VerticalBarChart/VerticalBarChart'
 import DonutChart, { typesRange, typesDomain } from '../DonutChart/DonutChart'
 import ProductionChart from '../ProductionChart/ProductionChart'
-import {
-  EmailShareButton,
-  FacebookShareButton,
-  TwitterShareButton
-} from 'react-share'
-import { faEnvelope, faNewspaper } from '@fortawesome/free-solid-svg-icons'
-import { faTwitter, faFacebook } from '@fortawesome/free-brands-svg-icons'
+import { faNewspaper } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faSignInAlt } from '@fortawesome/free-solid-svg-icons'
 
@@ -24,6 +18,7 @@ import {
 }from '../RepositoryMetadata/RepositoryMetadata'
 import styles from './RepositoryDetail.module.scss'
 import { MetricsDisplay } from '../MetricsDisplay/MetricsDisplay';
+import ShareLinks from '../ShareLinks/ShareLinks';
 
 export const REPOSITORY_DETAIL_FIELDS = gql`
   ${REPOSITORY_FIELDS}
@@ -184,23 +179,6 @@ export const RepositorySidebar: React.FunctionComponent<Props> = ({
     )
   }
 
-  const shareDisplay = () => {
-    const info = pageInfo(repo);
-    return (
-      <>
-        <h3>Share</h3>
-        <EmailShareButton url={info.pageUrl} title={info.title}>
-          <FontAwesomeIcon icon={faEnvelope} /> Email
-        </EmailShareButton>
-        <TwitterShareButton url={info.pageUrl} title={info.title}>
-          <FontAwesomeIcon icon={faTwitter} /> Twitter
-        </TwitterShareButton>
-        <FacebookShareButton url={info.pageUrl} title={info.title}>
-          <FontAwesomeIcon icon={faFacebook} /> Facebook
-        </FacebookShareButton>
-      </>
-    )
-  }
   return (
     <>
         <div className={styles.gotoButtons}>
@@ -210,7 +188,7 @@ export const RepositorySidebar: React.FunctionComponent<Props> = ({
           {contacts()}
         </div>
         <div className={styles.share}>
-          {shareDisplay()}
+          <ShareLinks url={"repositories/" + (repo.re3dataDoi ? repo.re3dataDoi: repo.id)} title={repo.name} />
         </div>
       </>
     )

--- a/src/components/ShareLinks/ShareLinks.tsx
+++ b/src/components/ShareLinks/ShareLinks.tsx
@@ -1,0 +1,62 @@
+import React from 'react'
+import { Row, Col } from 'react-bootstrap'
+import {
+  EmailShareButton,
+  FacebookShareButton,
+  TwitterShareButton
+} from 'react-share'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faEnvelope } from '@fortawesome/free-solid-svg-icons'
+import { faTwitter, faFacebook } from '@fortawesome/free-brands-svg-icons'
+
+type Props = {
+  url: string
+  title?: string
+}
+
+const ShareLinks: React.FunctionComponent<Props> = ({ url, title }) => {
+
+  const pageUrl =
+    process.env.NEXT_PUBLIC_API_URL === 'https://api.datacite.org'
+      ? 'https://commons.datacite.org/' + url
+      : 'https://commons.stage.datacite.org/' + url
+
+  const pageTitle = title
+    ? 'DataCite Commons: ' + title
+    : 'DataCite Commons: No Title'
+
+  const ShareLinks = () => <>
+    <h3 className="member-results" id="share">Share</h3>
+    <div className="panel panel-transparent share">
+      <div className="panel-body">
+        <Row>
+          <Col className="share-list" xs={12}>
+            <div>
+              <EmailShareButton url={pageUrl} title={pageTitle}>
+                <FontAwesomeIcon icon={faEnvelope} /> Email
+              </EmailShareButton>
+            </div>
+            <div>
+              <TwitterShareButton url={pageUrl} title={pageTitle}>
+                <FontAwesomeIcon icon={faTwitter} /> Twitter
+              </TwitterShareButton>
+            </div>
+            <div>
+              <FacebookShareButton url={pageUrl} title={pageTitle}>
+                <FontAwesomeIcon icon={faFacebook} /> Facebook
+              </FacebookShareButton>
+            </div>
+          </Col>
+        </Row>
+      </div>
+    </div>
+  </>
+
+  return (
+    <>
+      <ShareLinks />
+    </>
+  )
+}
+
+export default ShareLinks

--- a/src/components/Work/Work.tsx
+++ b/src/components/Work/Work.tsx
@@ -1,14 +1,6 @@
 import React from 'react'
-import { Tabs, Tab, Alert, Row, Col } from 'react-bootstrap'
+import { Tabs, Tab, Alert } from 'react-bootstrap'
 import { pluralize } from '../../utils/helpers'
-import {
-  EmailShareButton,
-  FacebookShareButton,
-  TwitterShareButton
-} from 'react-share'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faEnvelope } from '@fortawesome/free-solid-svg-icons'
-import { faTwitter, faFacebook } from '@fortawesome/free-brands-svg-icons'
 
 import { WorkType } from '../../pages/doi.org/[...doi]'
 import CitationFormatter from '../CitationFormatter/CitationFormatter'
@@ -25,48 +17,6 @@ const DoiPresentation: React.FunctionComponent<Props> = ({ doi }) => {
   const [selectedOption, setSelectedOption] = React.useState('')
 
   if (!doi) return <Alert bsStyle="warning">No works found.</Alert>
-
-  const pageUrl =
-    process.env.NEXT_PUBLIC_API_URL === 'https://api.datacite.org'
-      ? 'https://commons.datacite.org/doi.org/' + doi.doi
-      : 'https://commons.stage.datacite.org/doi.org/' + doi.doi
-
-  const title = doi.titles[0]
-    ? 'DataCite Commons: ' + doi.titles[0].title
-    : 'DataCite Commons: No Title'
-
-  const shareLink = () => {
-    return (
-      <>
-        <h3 className="member-results" id="share">
-          Share
-        </h3>
-        <div className="panel panel-transparent share">
-          <div className="panel-body">
-            <Row>
-              <Col className="share-list" xs={6} md={4}>
-                <div>
-                  <EmailShareButton url={pageUrl} title={title}>
-                    <FontAwesomeIcon icon={faEnvelope} /> Email
-                  </EmailShareButton>
-                </div>
-                <div>
-                  <TwitterShareButton url={pageUrl} title={title}>
-                    <FontAwesomeIcon icon={faTwitter} /> Twitter
-                  </TwitterShareButton>
-                </div>
-                <div>
-                  <FacebookShareButton url={pageUrl} title={title}>
-                    <FontAwesomeIcon icon={faFacebook} /> Facebook
-                  </FacebookShareButton>
-                </div>
-              </Col>
-            </Row>
-          </div>
-        </div>
-      </>
-    )
-  }
 
   const formattedCitation = () => {
     return (
@@ -155,7 +105,6 @@ const DoiPresentation: React.FunctionComponent<Props> = ({ doi }) => {
       { doi.registrationAgency.id == "datacite" && ( 
         <Claim doi_id={doi.doi} />
       )}
-      {shareLink()}
       {formattedCitation()}
       {analyticsBar()}
     </>

--- a/src/components/WorkFacets/WorkFacets.tsx
+++ b/src/components/WorkFacets/WorkFacets.tsx
@@ -89,7 +89,7 @@ const WorkFacets: React.FunctionComponent<Props> = ({
 
       {model == "person"
         ? <AuthorsFacet authors={data.authors} title="Co-Authors" url={url} model={model} />
-        : <AuthorsFacet authors={data.authors} title="Authors & Contributors" url={url} model={model} />
+        : <AuthorsFacet authors={data.authors} title="Authors" url={url} model={model} />
       }
 
       {data.published && data.published.length > 0 && (

--- a/src/pages/doi.org/[...doi].tsx
+++ b/src/pages/doi.org/[...doi].tsx
@@ -17,6 +17,7 @@ import {
   contentFragment
 } from '../../components/SearchWork/SearchWork'
 import { pluralize, rorFromUrl } from '../../utils/helpers'
+import ShareLinks from '../../components/ShareLinks/ShareLinks'
 
 type Props = {
   doi: string
@@ -625,6 +626,7 @@ const WorkPage: React.FunctionComponent<Props> = ({ doi, metadata }) => {
           title="Download Metadata"
           onClick={() => setShowDownloadMetadataModal(true)}
           id="download-metadata-button"
+          style={{marginBottom: 20}}
         >
           Download Metadata
         </Button>
@@ -646,6 +648,7 @@ const WorkPage: React.FunctionComponent<Props> = ({ doi, metadata }) => {
       <>
         <Col md={3} className="panel-list" id="side-bar">
           {downloadMetadataButton()}
+          <ShareLinks url={'doi.org/' + work.doi} title={work.titles[0] ? work.titles[0].title : undefined} />
         </Col>
         <Col md={9} className="panel-list" id="content">
           <Work doi={work}></Work>

--- a/src/pages/orcid.org/[orcid].tsx
+++ b/src/pages/orcid.org/[orcid].tsx
@@ -12,12 +12,13 @@ import Person from '../../components/Person/Person'
 import { WorkType } from '../doi.org/[...doi]'
 import WorksListing from '../../components/WorksListing/WorksListing'
 import Loading from '../../components/Loading/Loading'
-import { pluralize } from '../../utils/helpers'
+import { orcidFromUrl, pluralize } from '../../utils/helpers'
 import {
   PageInfo,
   connectionFragment,
   contentFragment
 } from '../../components/SearchWork/SearchWork'
+import ShareLinks from '../../components/ShareLinks/ShareLinks'
 
 type Props = {
   orcid?: string
@@ -262,9 +263,14 @@ const PersonPage: React.FunctionComponent<Props> = ({ orcid }) => {
 
   const content = () => {
     return (
-      <Col md={9} mdOffset={3}>
-        <Person person={person} />
-      </Col>
+      <>
+        <Col md={3} className="panel-list" id="side-bar">
+          <ShareLinks url={'orcid.org' + orcidFromUrl(person.id)} title={person.name} />
+        </Col>
+        <Col md={9} mdOffset={3}>
+          <Person person={person} />
+        </Col>
+      </>
     )
   }
 

--- a/src/pages/ror.org/[rorid].tsx
+++ b/src/pages/ror.org/[rorid].tsx
@@ -17,6 +17,7 @@ import {
   contentFragment
 } from '../../components/SearchWork/SearchWork'
 import { rorFromUrl, pluralize } from '../../utils/helpers'
+import ShareLinks from '../../components/ShareLinks/ShareLinks'
 
 type Props = {
   rorId?: string
@@ -233,9 +234,14 @@ const OrganizationPage: React.FunctionComponent<Props> = ({
 
   const content = () => {
     return (
-      <Col md={9} mdOffset={3}>
-        <Organization organization={organization} />
-      </Col>
+      <>
+        <Col md={3} className="panel-list" id="side-bar">
+          <ShareLinks url={'ror.org' + rorFromUrl(organization.id)} title={organization.name} />
+        </Col>
+        <Col md={9}>
+          <Organization organization={organization} />
+        </Col>
+      </>
     )
   }
 


### PR DESCRIPTION
## Purpose
Adds a left bar menu to the Organization, DOI, Person, and Repositories pages. It currently includes ShareLinks, which have been moved from the middle of the page.

![image](https://user-images.githubusercontent.com/43453735/218784945-a7c5663a-6906-4426-a5a0-2fd6c74a93d5.png)


Part of: https://github.com/datacite/datacite/issues/1730

## Approach
<!--- _How does this change address the problem?_ -->

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
