### PR TITLE
Updated example text on each index page

### DIFF
--- a/src/components/ExampleText/ExampleText.tsx
+++ b/src/components/ExampleText/ExampleText.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import { Row, Col, Alert } from 'react-bootstrap'
+
+const ExampleText: React.FunctionComponent = ({ children }) => {
+  return (
+    <Row>
+      <Col xs={12} md={9} mdOffset={3}>
+        <Alert bsStyle="info">
+          {children}
+        </Alert>
+      </Col>
+    </Row>
+  )
+}
+
+export default ExampleText

--- a/src/pages/doi.org/index.tsx
+++ b/src/pages/doi.org/index.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { useQueryState } from 'next-usequerystate'
 
 import Layout from '../../components/Layout/Layout'
-import Teaser from '../../components/Teaser/Teaser'
+import ExampleText from 'src/components/ExampleText/ExampleText'
 import SearchWork from '../../components/SearchWork/SearchWork'
 
 const IndexPage = () => {
@@ -11,7 +11,19 @@ const IndexPage = () => {
   return (
     <Layout path={'/doi.org'} >
       {!searchQuery || searchQuery === '' ? (
-        <Teaser title={'works'} />
+        <ExampleText>
+          <p>
+            Search works by keyword(s) or DOI.<br /><br />
+
+            Examples:
+            <ul>
+              <li><a href="/doi.org?query=climate+change">climate change</a></li>
+              <li><a href="/doi.org?query=10.14454%2F3w3z-sa82">10.14454/3w3z-sa82</a></li>
+            </ul>
+
+            Documentation is available in <a href="https://support.datacite.org/docs/datacite-commons" target="_blank" rel="noreferrer">DataCite Support.</a>
+          </p>
+        </ExampleText>
       ) : (
         <SearchWork searchQuery={searchQuery} />
       )}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { useQueryState } from 'next-usequerystate'
 
 import Layout from '../components/Layout/Layout'
-import Teaser from '../components/Teaser/Teaser'
+import ExampleText from 'src/components/ExampleText/ExampleText'
 import SearchWork from '../components/SearchWork/SearchWork'
 
 const IndexPage = () => {
@@ -11,7 +11,19 @@ const IndexPage = () => {
   return (
     <Layout path={'/doi.org'} >
       {!searchQuery || searchQuery === '' ? (
-        <Teaser title={'works'} />
+        <ExampleText>
+          <p>
+            Search works by keyword(s) or DOI.<br /><br />
+
+            Examples:
+            <ul>
+              <li><a href="/doi.org?query=climate+change">climate change</a></li>
+              <li><a href="/doi.org?query=10.14454%2F3w3z-sa82">10.14454/3w3z-sa82</a></li>
+            </ul>
+
+            Documentation is available in <a href="https://support.datacite.org/docs/datacite-commons" target="_blank" rel="noreferrer">DataCite Support.</a>
+          </p>
+        </ExampleText>
       ) : (
         <SearchWork searchQuery={searchQuery} />
       )}

--- a/src/pages/orcid.org/index.tsx
+++ b/src/pages/orcid.org/index.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { useQueryState } from 'next-usequerystate'
 
 import Layout from '../../components/Layout/Layout'
-import Teaser from '../../components/Teaser/Teaser'
+import ExampleText from 'src/components/ExampleText/ExampleText'
 import SearchPerson from '../../components/SearchPerson/SearchPerson'
 
 const IndexPersonPage = () => {
@@ -11,7 +11,19 @@ const IndexPersonPage = () => {
   return (
     <Layout path={'/orcid.org'} >
       {(!searchQuery || searchQuery === '') ? (
-        <Teaser title={'people'} />
+        <ExampleText>
+          <p>
+            Search people by name, keyword(s), or ORCID iD.<br /><br />
+
+            Examples:
+            <ul>
+              <li><a href="/orcid.org?query=Sofia+Maria+Hernandez+Garcia">Sofia Maria Hernandez Garcia</a></li>
+              <li><a href="/orcid.org?query=0000-0001-5727-2427">0000-0001-5727-2427</a></li>
+            </ul>
+
+            Documentation is available in <a href="https://support.datacite.org/docs/datacite-commons" target="_blank" rel="noreferrer">DataCite Support.</a>
+          </p>
+        </ExampleText>
       ) : (
         <SearchPerson searchQuery={searchQuery} />
       )}

--- a/src/pages/repositories/index.tsx
+++ b/src/pages/repositories/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { useQueryState } from 'next-usequerystate'
 
-import Teaser from '../../components/Teaser/Teaser'
+import ExampleText from 'src/components/ExampleText/ExampleText'
 import Layout from '../../components/Layout/Layout'
 import SearchRepository from '../../components/SearchRepository/SearchRepository'
 
@@ -11,7 +11,19 @@ const RepositoryIndexPage = () => {
   return (
     <Layout path={'/repositories'}>
         {!searchQuery || searchQuery === '' ? (
-          <Teaser title={'repositories'} />
+          <ExampleText>
+            <p>
+            Search repositories by repository name or keyword(s).<br /><br />
+
+              Examples:
+              <ul>
+                <li><a href="/repositories?query=Dryad">Dryad</a></li>
+                <li><a href="/repositories?query=biology">biology</a></li>
+              </ul>
+
+              Documentation is available in <a href="https://support.datacite.org/docs/datacite-commons" target="_blank" rel="noreferrer">DataCite Support.</a>
+            </p>
+          </ExampleText>
         ) : (
           <SearchRepository searchQuery={searchQuery} />
         )}

--- a/src/pages/ror.org/index.tsx
+++ b/src/pages/ror.org/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { useQueryState } from 'next-usequerystate'
 
-import Teaser from '../../components/Teaser/Teaser'
+import ExampleText from 'src/components/ExampleText/ExampleText'
 import Layout from '../../components/Layout/Layout'
 import SearchOrganization from '../../components/SearchOrganization/SearchOrganization'
 
@@ -11,7 +11,19 @@ const OrganizationIndexPage = () => {
   return (
     <Layout path={'/ror.org'}>
       {!searchQuery || searchQuery === '' ? (
-        <Teaser title={'organizations'} />
+        <ExampleText>
+          <p>
+            Search organizations by organization name, keyword(s), or ROR ID.<br /><br />
+
+            Examples:
+            <ul>
+              <li><a href="/ror.org?query=British+Library">British Library</a></li>
+              <li><a href="/ror.org?query=https%3A%2F%2Fror.org%2F05dhe8b71">https://ror.org/05dhe8b71</a></li>
+            </ul>
+
+            Documentation is available in <a href="https://support.datacite.org/docs/datacite-commons" target="_blank" rel="noreferrer">DataCite Support.</a>
+          </p>
+        </ExampleText>
       ) : (
         <SearchOrganization searchQuery={searchQuery} />
       )}


### PR DESCRIPTION
## Purpose
Replaces the current info box on Works, People, Organization, and Repository index pages with a more descriptive panel that includes search examples

<img width="1004" alt="image" src="https://github.com/datacite/akita/assets/43453735/519df260-ec9b-435b-b6db-94e8bb10a238">

closes: datacite/datacite#1912

## Approach
<!--- _How does this change address the problem?_ -->

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
