### PR TITLE
Do not cache multifacet values in memory

### DIFF
--- a/src/utils/apolloClient.ts
+++ b/src/utils/apolloClient.ts
@@ -49,6 +49,9 @@ const apolloClient = new ApolloClient({
       },
       Facet: {
         keyFields: false
+      },
+      MultiFacet: {
+        keyFields: false
       }
     }
   })


### PR DESCRIPTION
## Purpose
Apollo was caching values for multifacets, this is not desirable.  They should be treated much like regular facets.


## Approach
Disables inMemoryCache for multiFacets in the ApolloClient config.


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
