### PR TITLE
Separate loading and error handling for DOI, Organization, and Person pages

### DIFF
--- a/src/pages/doi.org/[...doi].tsx
+++ b/src/pages/doi.org/[...doi].tsx
@@ -597,44 +597,44 @@ const WorkPage: React.FunctionComponent<Props> = ({ doi, metadata, isBot = false
 
     if (!relatedContentQuery.data) return
 
-    const relatedContent = relatedContentQuery.data.work
+    const relatedWorks = relatedContentQuery.data.work
 
     if (
-      relatedContent.references.totalCount +
-      relatedContent.citations.totalCount +
-      relatedContent.parts.totalCount +
-      relatedContent.partOf.totalCount +
-      relatedContent.otherRelated.totalCount
+      relatedWorks.references.totalCount +
+      relatedWorks.citations.totalCount +
+      relatedWorks.parts.totalCount +
+      relatedWorks.partOf.totalCount +
+      relatedWorks.otherRelated.totalCount
       == 0
     ) return ''
 
-    const url = '/doi.org/' + relatedContent.doi + '/?'
+    const url = '/doi.org/' + relatedWorks.doi + '/?'
 
     const connectionTypeCounts = {
-      references: relatedContent.references.totalCount,
-      citations: relatedContent.citations.totalCount,
-      parts: relatedContent.parts.totalCount,
-      partOf: relatedContent.partOf.totalCount,
-      otherRelated: relatedContent.otherRelated.totalCount
+      references: relatedWorks.references.totalCount,
+      citations: relatedWorks.citations.totalCount,
+      parts: relatedWorks.parts.totalCount,
+      partOf: relatedWorks.partOf.totalCount,
+      otherRelated: relatedWorks.otherRelated.totalCount
     }
 
     const defaultConnectionType =
-      relatedContent.references.totalCount > 0 ? 'references' :
-      relatedContent.citations.totalCount > 0 ? 'citations' :
-      relatedContent.parts.totalCount > 0 ? 'parts' :
-      relatedContent.partOf.totalCount > 0 ? 'partOf' : 'otherRelated'
+      relatedWorks.references.totalCount > 0 ? 'references' :
+      relatedWorks.citations.totalCount > 0 ? 'citations' :
+      relatedWorks.parts.totalCount > 0 ? 'parts' :
+      relatedWorks.partOf.totalCount > 0 ? 'partOf' : 'otherRelated'
 
     const displayedConnectionType = connectionType ? connectionType : defaultConnectionType
 
 
-    const works: Works = displayedConnectionType in relatedContent ?
-      relatedContent[displayedConnectionType] :
+    const works: Works = displayedConnectionType in relatedWorks ?
+      relatedWorks[displayedConnectionType] :
       { totalCount: 0, nodes: [] }
 
     const hasNextPage = works.pageInfo ? works.pageInfo.hasNextPage : false
     const endCursor = works.pageInfo ? works.pageInfo.endCursor : ''
     
-    const showSankey = isDMP(relatedContent) || isProject(relatedContent)
+    const showSankey = isDMP(relatedWorks) || isProject(relatedWorks)
     
     return (
       <>

--- a/src/pages/doi.org/[...doi].tsx
+++ b/src/pages/doi.org/[...doi].tsx
@@ -90,63 +90,59 @@ interface MetadataType {
   schemaOrg: string
 }
 
-const BASE_DOI_GQL = `
-  ...WorkFragment
-  contentUrl
-  contributors {
-    id
-    givenName
-    familyName
-    name
-    contributorType
-    affiliation {
-      id
-      name
-    }
-  }
-  fundingReferences {
-    funderIdentifier
-    funderIdentifierType
-    funderName
-    awardTitle
-    awardUri
-    awardNumber
-  }
-  claims {
-    id
-    sourceId
-    state
-    claimAction
-    claimed
-    errorMessages {
-      status
-      title
-    }
-  }
-  formattedCitation
-  schemaOrg
-  viewsOverTime {
-    yearMonth
-    total
-  }
-  downloadsOverTime {
-    yearMonth
-    total
-  }
-`
-
-const LIGHTWEIGHT_DOI_GQL = gql`
+const DOI_GQL = gql`
   query getDoiQuery(
     $id: ID!
   ) {
     work(id: $id) {
-      ${BASE_DOI_GQL}
+      ...WorkFragment
+      contentUrl
+      contributors {
+        id
+        givenName
+        familyName
+        name
+        contributorType
+        affiliation {
+          id
+          name
+        }
+      }
+      fundingReferences {
+        funderIdentifier
+        funderIdentifierType
+        funderName
+        awardTitle
+        awardUri
+        awardNumber
+      }
+      claims {
+        id
+        sourceId
+        state
+        claimAction
+        claimed
+        errorMessages {
+          status
+          title
+        }
+      }
+      formattedCitation
+      schemaOrg
+      viewsOverTime {
+        yearMonth
+        total
+      }
+      downloadsOverTime {
+        yearMonth
+        total
+      }
     }
   }
   ${contentFragment.work}
 `
 
-export const DOI_GQL = gql`
+export const RELATED_CONTENT_GQL = gql`
   query getDoiQuery(
     $id: ID!
     $filterQuery: String
@@ -160,7 +156,11 @@ export const DOI_GQL = gql`
     $repositoryId: String
   ) {
     work(id: $id) {
-      ${BASE_DOI_GQL}
+      doi,
+      types {
+        resourceTypeGeneral,
+        resourceType
+      },
       citations(
         first: 25
         query: $filterQuery
@@ -507,38 +507,42 @@ const WorkPage: React.FunctionComponent<Props> = ({ doi, metadata, isBot = false
   const [registrationAgency] = useQueryState('registration-agency', { history: 'push' })
   const [connectionType] = useQueryState('connection-type', { history: 'push' })
 
-  const { loading, error, data } = useQuery<WorkQueryData, QueryVar>(isBot ? LIGHTWEIGHT_DOI_GQL : DOI_GQL, {
+  const variables = {
+    id: doi,
+    cursor: cursor,
+    filterQuery: filterQuery,
+    published: published as string,
+    resourceTypeId: resourceType as string,
+    fieldOfScience: fieldOfScience as string,
+    language: language as string,
+    license: license as string,
+    registrationAgency: registrationAgency as string
+  }
+
+  const doiQuery = useQuery<WorkQueryData, QueryVar>(DOI_GQL, { errorPolicy: 'all', variables: variables })
+  const relatedContentQuery = useQuery<WorkQueryData, QueryVar>(RELATED_CONTENT_GQL, {
     errorPolicy: 'all',
-    variables: {
-      id: doi,
-      cursor: cursor,
-      filterQuery: filterQuery,
-      published: published as string,
-      resourceTypeId: resourceType as string,
-      fieldOfScience: fieldOfScience as string,
-      language: language as string,
-      license: license as string,
-      registrationAgency: registrationAgency as string
-    }
+    variables: variables,
+    skip: isBot
   })
 
-  if (loading)
+  if (doiQuery.loading)
     return (
       <Layout path={'/doi.org/' + doi}>
         <Loading />
       </Layout>
     )
 
-  if (error)
+  if (doiQuery.error)
     return (
       <Layout path={'/doi.org/' + doi}>
         <Col md={9} mdOffset={3}>
-          <Error title="An error occured." message={error.message} />
+          <Error title="An error occured." message={doiQuery.error.message} />
         </Col>
       </Layout>
     )
 
-  const work = data.work
+  const work = doiQuery.data.work
 
 
   const content = () => {
@@ -582,42 +586,55 @@ const WorkPage: React.FunctionComponent<Props> = ({ doi, metadata, isBot = false
   }
 
   const relatedContent = () => {
+    if (relatedContentQuery.loading) return <Loading />
+
+    if (relatedContentQuery.error)
+      return <Row>
+        <Col mdOffset={3} className="panel panel-transparent">
+          <Error title="An error occured loading related content." message={relatedContentQuery.error.message} />
+        </Col>
+      </Row>
+
+    if (!relatedContentQuery.data) return
+
+    const relatedContent = relatedContentQuery.data.work
+
     if (
-      work.references.totalCount +
-      work.citations.totalCount +
-      work.parts.totalCount +
-      work.partOf.totalCount +
-      work.otherRelated.totalCount
+      relatedContent.references.totalCount +
+      relatedContent.citations.totalCount +
+      relatedContent.parts.totalCount +
+      relatedContent.partOf.totalCount +
+      relatedContent.otherRelated.totalCount
       == 0
     ) return ''
 
-    const url = '/doi.org/' + work.doi + '/?'
+    const url = '/doi.org/' + relatedContent.doi + '/?'
 
     const connectionTypeCounts = {
-      references: work.references.totalCount,
-      citations: work.citations.totalCount,
-      parts: work.parts.totalCount,
-      partOf: work.partOf.totalCount,
-      otherRelated: work.otherRelated.totalCount
+      references: relatedContent.references.totalCount,
+      citations: relatedContent.citations.totalCount,
+      parts: relatedContent.parts.totalCount,
+      partOf: relatedContent.partOf.totalCount,
+      otherRelated: relatedContent.otherRelated.totalCount
     }
 
     const defaultConnectionType =
-      work.references.totalCount > 0 ? 'references' :
-      work.citations.totalCount > 0 ? 'citations' :
-      work.parts.totalCount > 0 ? 'parts' :
-      work.partOf.totalCount > 0 ? 'partOf' : 'otherRelated'
+      relatedContent.references.totalCount > 0 ? 'references' :
+      relatedContent.citations.totalCount > 0 ? 'citations' :
+      relatedContent.parts.totalCount > 0 ? 'parts' :
+      relatedContent.partOf.totalCount > 0 ? 'partOf' : 'otherRelated'
 
     const displayedConnectionType = connectionType ? connectionType : defaultConnectionType
 
 
-    const works: Works = displayedConnectionType in work ?
-      work[displayedConnectionType] :
+    const works: Works = displayedConnectionType in relatedContent ?
+      relatedContent[displayedConnectionType] :
       { totalCount: 0, nodes: [] }
 
     const hasNextPage = works.pageInfo ? works.pageInfo.hasNextPage : false
     const endCursor = works.pageInfo ? works.pageInfo.endCursor : ''
     
-    const showSankey = isDMP(work) || isProject(work)
+    const showSankey = isDMP(relatedContent) || isProject(relatedContent)
     
     return (
       <>
@@ -679,7 +696,7 @@ const WorkPage: React.FunctionComponent<Props> = ({ doi, metadata, isBot = false
       <TitleComponent title={ReactHtmlParser(titleHtml)} titleLink={handleUrl} link={'https://doi.org/' + work.doi} rights={work.rights} />
            
       {content()}
-      {!isBot && relatedContent()}
+      {relatedContent()}
     </Layout>
   )
 }

--- a/src/pages/orcid.org/[orcid].tsx
+++ b/src/pages/orcid.org/[orcid].tsx
@@ -305,16 +305,16 @@ const PersonPage: React.FunctionComponent<Props> = ({ orcid, isBot = false }) =>
 
     if (!relatedContentQuery.data) return
 
-    const relatedContent = relatedContentQuery.data.person.works
+    const relatedWorks = relatedContentQuery.data.person.works
 
-    const hasNextPage = relatedContent.pageInfo
-      ? relatedContent.pageInfo.hasNextPage
+    const hasNextPage = relatedWorks.pageInfo
+      ? relatedWorks.pageInfo.hasNextPage
       : false
-    const endCursor = relatedContent.pageInfo
-      ? relatedContent.pageInfo.endCursor
+    const endCursor = relatedWorks.pageInfo
+      ? relatedWorks.pageInfo.endCursor
       : ''
 
-    const totalCount = relatedContent.totalCount
+    const totalCount = relatedWorks.totalCount
 
     return (
       <>
@@ -322,12 +322,12 @@ const PersonPage: React.FunctionComponent<Props> = ({ orcid, isBot = false }) =>
           <h3 className="member-results">{pluralize(totalCount, 'Work')}</h3>
         </Col>
         <WorksListing
-          works={relatedContent}
+          works={relatedWorks}
           loading={relatedContentQuery.loading}
           showFacets={true}
           showAnalytics={true}
           showClaimStatus={true}
-          hasPagination={relatedContent.totalCount > 25}
+          hasPagination={relatedWorks.totalCount > 25}
           hasNextPage={hasNextPage}
           model={'person'}
           url={'/orcid.org/' + orcid + '/?'}

--- a/src/pages/orcid.org/[orcid].tsx
+++ b/src/pages/orcid.org/[orcid].tsx
@@ -27,59 +27,55 @@ type Props = {
   isBot?: boolean
 }
 
-const BASE_PERSON_GQL = `
-  id
-  description
-  links {
-    url
-    name
-  }
-  identifiers {
-    identifier
-    identifierType
-    identifierUrl
-  }
-  country {
-    name
-    id
-  }
-  name
-  alternateName
-  givenName
-  familyName
-  employment {
-    organizationId
-    organizationName
-    roleTitle
-    startDate
-    endDate
-  }
-  citationCount
-  viewCount
-  downloadCount
-  totalWorks: works {
-    totalCount
-    totalContentUrl
-    totalOpenLicenses
-    openLicenseResourceTypes {
-      id
-      title
-      count
-    }
-  }
-`
-
-const LIGHTWEIGHT_PERSON_GQL = gql`
+const PERSON_GQL = gql`
   query getContentQuery(
     $id: ID!
   ) {
     person(id: $id) {
-      ${BASE_PERSON_GQL}
+      id
+      description
+      links {
+        url
+        name
+      }
+      identifiers {
+        identifier
+        identifierType
+        identifierUrl
+      }
+      country {
+        name
+        id
+      }
+      name
+      alternateName
+      givenName
+      familyName
+      employment {
+        organizationId
+        organizationName
+        roleTitle
+        startDate
+        endDate
+      }
+      citationCount
+      viewCount
+      downloadCount
+      totalWorks: works {
+        totalCount
+        totalContentUrl
+        totalOpenLicenses
+        openLicenseResourceTypes {
+          id
+          title
+          count
+        }
+      }
     }
   }
 `
 
-export const PERSON_GQL = gql`
+export const RELATED_CONTENT_GQL = gql`
   query getContentQuery(
     $id: ID!
     $filterQuery: String
@@ -92,7 +88,6 @@ export const PERSON_GQL = gql`
     $registrationAgency: String
   ) {
     person(id: $id) {
-      ${BASE_PERSON_GQL}
       works(
         first: 25
         query: $filterQuery
@@ -226,41 +221,43 @@ const PersonPage: React.FunctionComponent<Props> = ({ orcid, isBot = false }) =>
     history: 'push'
   })
 
-  const { loading, error, data } = useQuery<OrcidDataQuery, OrcidQueryVar>(
-    isBot ? LIGHTWEIGHT_PERSON_GQL : PERSON_GQL,
-    {
+  const variables = {
+    id: 'http://orcid.org/' + orcid,
+    filterQuery: filterQuery,
+    cursor: cursor,
+    published: published as string,
+    resourceTypeId: resourceType as string,
+    fieldOfScience: fieldOfScience as string,
+    language: language as string,
+    license: license as string,
+    registrationAgency: registrationAgency as string
+  }
+
+  const personQuery = useQuery<OrcidDataQuery, OrcidQueryVar>(PERSON_GQL, { errorPolicy: 'all', variables: variables })
+  const relatedContentQuery = useQuery<OrcidDataQuery, OrcidQueryVar>(RELATED_CONTENT_GQL, {
       errorPolicy: 'all',
-      variables: {
-        id: 'http://orcid.org/' + orcid,
-        filterQuery: filterQuery,
-        cursor: cursor,
-        published: published as string,
-        resourceTypeId: resourceType as string,
-        fieldOfScience: fieldOfScience as string,
-        language: language as string,
-        license: license as string,
-        registrationAgency: registrationAgency as string
-      }
+      variables: variables,
+      skip: isBot
     }
   )
 
-  if (loading)
+  if (personQuery.loading)
     return (
       <Layout path={'/orcid.org/' + orcid}>
         <Loading />
       </Layout>
     )
 
-  if (error)
+  if (personQuery.error)
     return (
       <Layout path={'/orcid.org/' + orcid}>
         <Col md={9} mdOffset={3}>
-          <Error title="An error occured." message={error.message} />
+          <Error title="An error occured." message={personQuery.error.message} />
         </Col>
       </Layout>
     )
 
-  const person = data.person
+  const person = personQuery.data.person
 
   const pageUrl =
     process.env.NEXT_PUBLIC_API_URL === 'https://api.datacite.org'
@@ -297,14 +294,27 @@ const PersonPage: React.FunctionComponent<Props> = ({ orcid, isBot = false }) =>
   }
 
   const relatedContent = () => {
-    const hasNextPage = person.works.pageInfo
-      ? person.works.pageInfo.hasNextPage
+    if (relatedContentQuery.loading) return <Loading />
+
+    if (relatedContentQuery.error)
+      return <Row>
+        <Col mdOffset={3} className="panel panel-transparent">
+          <Error title="An error occured loading related content." message={relatedContentQuery.error.message} />
+        </Col>
+      </Row>
+
+    if (!relatedContentQuery.data) return
+
+    const relatedContent = relatedContentQuery.data.person.works
+
+    const hasNextPage = relatedContent.pageInfo
+      ? relatedContent.pageInfo.hasNextPage
       : false
-    const endCursor = person.works.pageInfo
-      ? person.works.pageInfo.endCursor
+    const endCursor = relatedContent.pageInfo
+      ? relatedContent.pageInfo.endCursor
       : ''
 
-    const totalCount = person.works.totalCount
+    const totalCount = relatedContent.totalCount
 
     return (
       <>
@@ -312,12 +322,12 @@ const PersonPage: React.FunctionComponent<Props> = ({ orcid, isBot = false }) =>
           <h3 className="member-results">{pluralize(totalCount, 'Work')}</h3>
         </Col>
         <WorksListing
-          works={person.works}
-          loading={loading}
+          works={relatedContent}
+          loading={relatedContentQuery.loading}
           showFacets={true}
           showAnalytics={true}
           showClaimStatus={true}
-          hasPagination={person.works.totalCount > 25}
+          hasPagination={relatedContent.totalCount > 25}
           hasNextPage={hasNextPage}
           model={'person'}
           url={'/orcid.org/' + orcid + '/?'}
@@ -348,7 +358,7 @@ const PersonPage: React.FunctionComponent<Props> = ({ orcid, isBot = false }) =>
         </Col>
       </Row>
       <Row>{content()}</Row>
-      {!isBot && <Row>{relatedContent()}</Row>}
+      <Row>{relatedContent()}</Row>
     </Layout>
   )
 }

--- a/src/pages/ror.org/[rorid].tsx
+++ b/src/pages/ror.org/[rorid].tsx
@@ -322,14 +322,14 @@ const OrganizationPage: React.FunctionComponent<Props> = ({
 
     if (!relatedContentQuery.data) return
 
-    const relatedContent = relatedContentQuery.data.organization.works
+    const relatedWorks = relatedContentQuery.data.organization.works
 
-    const hasNextPage = relatedContent.totalCount > 25
-    const endCursor = relatedContent.pageInfo
-      ? relatedContent.pageInfo.endCursor
+    const hasNextPage = relatedWorks.totalCount > 25
+    const endCursor = relatedWorks.pageInfo
+      ? relatedWorks.pageInfo.endCursor
       : ''
 
-    const totalCount = relatedContent.totalCount
+    const totalCount = relatedWorks.totalCount
 
     return (
       <div>
@@ -339,12 +339,12 @@ const OrganizationPage: React.FunctionComponent<Props> = ({
           )}
         </Col>
         <WorksListing
-          works={relatedContent}
+          works={relatedWorks}
           loading={relatedContentQuery.loading}
           showFacets={true}
           showAnalytics={true}
           showClaimStatus={true}
-          hasPagination={relatedContent.totalCount > 25}
+          hasPagination={relatedWorks.totalCount > 25}
           hasNextPage={hasNextPage}
           model={'organization'}
           url={'/ror.org/' + rorId + '/?'}


### PR DESCRIPTION
## Purpose
Currently, all of the data is fetched in one big pass. These changes split up the query into two separate queries that can run in parallel, allowing it to quickly fetch and show the metadata for the DOI, organization, or person, while loading the related content.

Additionally, if an error occurs during the related content loading, the metadata section will still be shown, and an error message will only be shown in the related content section.


## Approach
For each page, the query has been split up into two queries, metadata and related content, that run in parallel. They each have their own rendering and handling logic

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
