### PR TITLE
Fixed middleware and added more bot download prevention

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,5 +1,6 @@
-import { NextRequest, NextResponse } from 'next/server'
-import { isBot } from './utils/helpers'
+/* istanbul ignore file */
+
+import { NextRequest, NextResponse, userAgent } from 'next/server'
  
 export function middleware(request: NextRequest) {
   
@@ -7,4 +8,12 @@ export function middleware(request: NextRequest) {
   url.searchParams.set('isBot', JSON.stringify(isBot(request)))
 
   return NextResponse.rewrite(url)
+}
+
+
+const CUSTOM_BOTS = /Google-InspectionTool|GoogleOther|Google-Extended/i
+
+const isBot = (request: NextRequest) => {
+  const ua = request.headers.get('user-agent') || ''
+  return userAgent(request).isBot || CUSTOM_BOTS.test(ua)
 }

--- a/src/pages/doi.org/[...doi].tsx
+++ b/src/pages/doi.org/[...doi].tsx
@@ -555,7 +555,7 @@ const WorkPage: React.FunctionComponent<Props> = ({ doi, metadata, isBot = false
             <DownloadMetadata doi={work} />
           </div>
           <CiteAs doi={work} />
-          <DownloadReports
+          { !isBot && <DownloadReports
             links={[
               {
                 title: 'Related Works (CSV)',
@@ -574,7 +574,7 @@ const WorkPage: React.FunctionComponent<Props> = ({ doi, metadata, isBot = false
               license: license,
               registrationAgency: registrationAgency
             }}
-          />
+          /> }
           <ShareLinks url={'doi.org/' + work.doi} title={work.titles[0] ? work.titles[0].title : undefined} />
         </Col>
         <Col md={9} id="content">

--- a/src/pages/ror.org/[rorid].tsx
+++ b/src/pages/ror.org/[rorid].tsx
@@ -273,7 +273,7 @@ const OrganizationPage: React.FunctionComponent<Props> = ({
     return (
       <>
         <Col md={3} className="panel-list" id="side-bar">
-          <DownloadReports
+          { !isBot && <DownloadReports
             links={[
               {
                 title: 'Related Works (CSV)',
@@ -299,7 +299,7 @@ const OrganizationPage: React.FunctionComponent<Props> = ({
               license: license,
               registrationAgency: registrationAgency
             }}
-          />
+          /> }
           <ShareLinks url={'ror.org' + rorFromUrl(organization.id)} title={organization.name} />
         </Col>
         <Col md={9}>

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,6 +1,5 @@
 import '@formatjs/intl-numberformat/polyfill'
 import '@formatjs/intl-numberformat/locale-data/en'
-import { NextRequest, userAgent } from 'next/server'
 
 export const compactNumbers = (num: number, compact: boolean = false) => {
   let options = {}
@@ -36,11 +35,4 @@ export const rorFromUrl = (rorUrl: string) => {
 
 export const gridFromUrl = (gridUrl: string) => {
   return gridUrl ? gridUrl.substring(15) : null
-}
-
-const CUSTOM_BOTS = /GoogleOther|Google-Extended/i
-
-export const isBot = (request: NextRequest) => {
-  const ua = request.headers.get('user-agent') || ''
-  return userAgent(request).isBot || CUSTOM_BOTS.test(ua)
 }


### PR DESCRIPTION
## Purpose
Bots no longer see Download Reports section on DOI and organization pages. Also fixed middleware failing during build step



## Approach
The middleware was failing in the build step due to incompatibility with the bable plugin istanbul. Adding a line to ignore it at the top of the file, as well as moving the related isBot function into the middleware file, resolved the issue. 

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
