### PR TITLE
Repository contacts display

### DIFF
--- a/src/components/RepositoryDetail/RepositoryDetail.module.scss
+++ b/src/components/RepositoryDetail/RepositoryDetail.module.scss
@@ -78,7 +78,19 @@
   display: flex;
   flex-direction: column;
   margin-top: 15px;
+  .contactList {
+    display: flex;
+    flex-direction: column;
+    list-style: none;
+    padding: 0;
+    padding-left: 15px;
+    margin: 0;
+    li {
+      margin-bottom: 5px;
+    }
+  }
 }
+
 .gotoButtons {
   display: flex;
   flex-direction: column;
@@ -89,6 +101,5 @@
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-
   @include header-style();
 }

--- a/src/components/RepositoryDetail/RepositoryDetail.tsx
+++ b/src/components/RepositoryDetail/RepositoryDetail.tsx
@@ -170,13 +170,12 @@ export const RepositorySidebar: React.FunctionComponent<Props> = ({
         { (repo.contact?.length > 0) && (
         <>
         <h3 className="member-results">Contacts</h3>
-        <div className="panel panel-transparent share">
-          <div className="panel-body">
-            { contactsData.map((contact, index) => (
-              <a id={"contact-link-"+ index} key={"contact-"+ index} href={contact.link}>{contact.text}</a>
-            ))}
-          </div>
-        </div>
+
+	<ul className={styles.contactList}>
+	{ contactsData.map((contact, index) => (
+	<li key={"contact-"+ index}><a id={"contact-link-"+ index} href={contact.link}>{contact.text}</a></li>
+				))}
+	</ul>
       </>
       )}
     </>
@@ -227,7 +226,7 @@ export const RepositoryDetail: React.FunctionComponent<Props> = ({
             domain={resourceTypeDomain}
             range={resourceTypeRange}
             tooltipText={'The field resourceType from DOI metadata was used to generate this chart.'} />
-        <HorizontalStackedBarChart 
+        <HorizontalStackedBarChart
           chartTitle='Licenses'
           topCategory={{ title: licenses.topCategory, percent: licenses.topPercent}}
           data={licenses.data}


### PR DESCRIPTION
## Purpose
The list of contacts in the Repository page would often overlap with the main seciton of the page.
Also the contacts would be squashed together.

## Approach
Add appropriate css to fix this.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
