### PR TITLE
Fix Sankey chart bug

### DIFF
--- a/src/components/SankeyGraph/SankeyGraph.tsx
+++ b/src/components/SankeyGraph/SankeyGraph.tsx
@@ -17,12 +17,34 @@ type Props = {
 
 
 export function multilevelToSankey(facets: MultilevelFacet[]): SankeyGraphData[] {
-  let data: SankeyGraphData[] = []
+  const outerMap = new Map<SankeyGraphData['data'][0], Map<SankeyGraphData['data'][1], SankeyGraphData['count']>>();
   facets = facets.filter(f => f.title)
 
   facets.forEach(facet => {
-    const arr: SankeyGraphData[] = facet.inner.map(i => ({ data: [facet.title, i.title], count: i.count }))
-    data = data.concat(arr)
+    facet.inner.forEach(i => {
+      const outerKey = facet.title
+      const innerKey = i.title
+      const count = i.count
+
+      let innerMap = outerMap.get(outerKey)
+      
+      if (!innerMap) {
+        innerMap = new Map<SankeyGraphData['data'][1], SankeyGraphData['count']>()
+        outerMap.set(outerKey, innerMap)
+      }
+
+      const previousCount = innerMap.get(innerKey) || 0
+      const totalCount = count + previousCount
+      innerMap.set(innerKey, totalCount)
+    })
+  })
+
+  const data: SankeyGraphData[] = []
+
+  outerMap.forEach((innerMap, outerKey) => {
+    innerMap.forEach((count, innerKey) => {
+      data.push({ data: [outerKey, innerKey], count })
+    })
   })
 
   return data


### PR DESCRIPTION
## Purpose
Sankey charts may have wrong bar heights
<img width="935" alt="image" src="https://github.com/datacite/akita/assets/43453735/4a21f996-2c89-4127-bb41-f9b5bf1a610a">



This change fixes that
<img width="928" alt="image" src="https://github.com/datacite/akita/assets/43453735/0376771b-bc8f-4019-ad43-4cc6f020c3ea">



## Approach
<!--- _How does this change address the problem?_ -->

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
