### PR TITLE
Revert "Update ClaimStatus element for styling consistency"

### DIFF
--- a/src/components/ClaimStatus/ClaimStatus.tsx
+++ b/src/components/ClaimStatus/ClaimStatus.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Tooltip, Button } from 'react-bootstrap'
+import { Tooltip, Label } from 'react-bootstrap'
 import OverlayTrigger from '../OverlayTrigger/OverlayTrigger'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faOrcid } from '@fortawesome/free-brands-svg-icons'
@@ -37,9 +37,9 @@ const ClaimStatus: React.FunctionComponent<Props> = ({ claim }) => {
     return (
         <>
             <OverlayTrigger placement="top" overlay={tooltipClaimStatus}>
-                <Button disabled block bsStyle={stateColors[claim.state]}>
+                <Label bsStyle={stateColors[claim.state]}>
                     <FontAwesomeIcon icon={faOrcid} /> {stateText[claim.state]}
-                </Button>
+                </Label>
             </OverlayTrigger>
         </>
     )


### PR DESCRIPTION
This reverts commit 5716bf58fbecb953878bc20c4832f5a9aa41f29a. The label element display of the component was intentional in WorkMetadata: https://github.com/datacite/akita/blob/dd0845e7b9e1e4d4d37e9476a2c9d17a8912d478/src/components/WorkMetadata/WorkMetadata.tsx#L265-L267  

## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

closes: _Add github issue that originated this PR_

## Approach
<!--- _How does this change address the problem?_ -->

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
