### PR TITLE
Add All option to related works filters

### DIFF
--- a/src/app/doi.org/[...doi]/RelatedContent.tsx
+++ b/src/app/doi.org/[...doi]/RelatedContent.tsx
@@ -45,6 +45,7 @@ export default function RelatedContent(props: Props) {
 
   const relatedWorks = data.work
 
+  const allRelatedCount = relatedWorks.allRelated?.totalCount || 0
   const referenceCount = relatedWorks.references?.totalCount || 0
   const citationCount = relatedWorks.citations?.totalCount || 0
   const partCount = relatedWorks.parts?.totalCount || 0
@@ -56,6 +57,7 @@ export default function RelatedContent(props: Props) {
   const url = '/doi.org/' + relatedWorks.doi + '/?'
 
   const connectionTypeCounts = {
+    allRelated: allRelatedCount,
     references: referenceCount,
     citations: citationCount,
     parts: partCount,

--- a/src/app/doi.org/[...doi]/RelatedContent.tsx
+++ b/src/app/doi.org/[...doi]/RelatedContent.tsx
@@ -66,10 +66,11 @@ export default function RelatedContent(props: Props) {
   }
 
   const defaultConnectionType =
+    allRelatedCount > 0 ? 'allRelated' :
     referenceCount > 0 ? 'references' :
-      citationCount > 0 ? 'citations' :
-        partCount > 0 ? 'parts' :
-          partOfCount > 0 ? 'partOf' : 'otherRelated'
+    citationCount > 0 ? 'citations' :
+    partCount > 0 ? 'parts' :
+    partOfCount > 0 ? 'partOf' : 'otherRelated'
 
   const displayedConnectionType = connectionType ? connectionType : defaultConnectionType
 

--- a/src/app/doi.org/[...doi]/RelatedContent.tsx
+++ b/src/app/doi.org/[...doi]/RelatedContent.tsx
@@ -73,6 +73,14 @@ export default function RelatedContent(props: Props) {
     partOfCount > 0 ? 'partOf' : 'otherRelated'
 
   const displayedConnectionType = connectionType ? connectionType : defaultConnectionType
+  //convert camel case to title and make first letter uppercase
+  //convert connectionType to title, allRelated becomes All Related Wokrs, references becomes References, citations becomes Citations, parts becomes Parts, partOf becomes Part Of, and otherRelated becomes Other Works
+  const displayedConnectionTitle =
+    displayedConnectionType === 'allRelated' ? 'All Related Works' :
+    displayedConnectionType === 'otherRelated' ? 'Other Works' :
+    displayedConnectionType.replace(/([A-Z])/g, ' $1').replace(/^./, str => str.toUpperCase())
+
+
 
 
   const works: Works = displayedConnectionType in relatedWorks ?
@@ -101,7 +109,7 @@ export default function RelatedContent(props: Props) {
               connectionTypesCounts={connectionTypeCounts}
               showAnalytics={true}
               showSankey={showSankey}
-              sankeyTitle={`Contributions to ${displayedConnectionType}`}
+              sankeyTitle={`Contributions to ${displayedConnectionTitle}`}
               showClaimStatus={true}
               hasPagination={works.totalCount > 25}
               hasNextPage={hasNextPage}

--- a/src/components/WorkFacets/WorkFacets.tsx
+++ b/src/components/WorkFacets/WorkFacets.tsx
@@ -12,7 +12,7 @@ interface Props {
   model: string
   url: string
   loading: boolean
-  connectionTypesCounts?: { references: number, citations: number, parts: number, partOf: number, otherRelated: number }
+  connectionTypesCounts?: { references: number, citations: number, parts: number, partOf: number, otherRelated: number, allRelated: number }
 }
 
 interface Facets {
@@ -50,6 +50,7 @@ export default function WorkFacets({
   const path = url.substring(0, url.length - 2)
 
   const connectionTypeList: Facet[] = connectionTypesCounts ? [
+    { id: 'allRelated', title: 'All', count: connectionTypesCounts.allRelated },
     { id: 'references', title: 'References', count: connectionTypesCounts.references },
     { id: 'citations', title: 'Citations', count: connectionTypesCounts.citations },
     { id: 'parts', title: 'Parts', count: connectionTypesCounts.parts },

--- a/src/components/WorksListing/WorksListing.tsx
+++ b/src/components/WorksListing/WorksListing.tsx
@@ -17,7 +17,7 @@ interface Props {
   showSankey?: boolean
   sankeyTitle?: string
   showFacets: boolean
-  connectionTypesCounts?: { references: number, citations: number, parts: number, partOf: number, otherRelated: number }
+  connectionTypesCounts?: { references: number, citations: number, parts: number, partOf: number, otherRelated: number , allRelated: number}
   showClaimStatus: boolean
   loading: boolean
   model: string

--- a/src/data/queries/doiQuery.ts
+++ b/src/data/queries/doiQuery.ts
@@ -109,7 +109,7 @@ export const workFragment = gql`
       title
     }
     repository {
-      id:uid
+      id: uid
       name
     }
     rights {
@@ -164,9 +164,7 @@ export const DOI_METADATA_QUERY = gql`
 `
 
 export const DOI_QUERY = gql`
-  query getDoiQuery(
-    $id: ID!
-  ) {
+  query getDoiQuery($id: ID!) {
     work(id: $id) {
       ...WorkFragment
       contentUrl
@@ -229,11 +227,28 @@ export const RELATED_CONTENT_QUERY = gql`
     $repositoryId: String
   ) {
     work(id: $id) {
-      doi,
+      doi
       types {
-        resourceTypeGeneral,
+        resourceTypeGeneral
         resourceType
-      },
+      }
+      allRelated(
+        first: 25
+        query: $filterQuery
+        after: $cursor
+        published: $published
+        resourceTypeId: $resourceTypeId
+        fieldOfScience: $fieldOfScience
+        language: $language
+        license: $license
+        registrationAgency: $registrationAgency
+        repositoryId: $repositoryId
+      ) {
+        ...WorkConnectionFragment
+        nodes {
+          ...WorkFragment
+        }
+      }
       citations(
         first: 25
         query: $filterQuery
@@ -332,7 +347,6 @@ export interface MetadataQueryVar {
 export interface MetadataQueryData {
   work: WorkMetadata
 }
-
 
 export interface QueryData {
   work: Work

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -40,7 +40,7 @@ export type Work = WorkMetadata & {
     id: string
     name: string
   }
-  
+
   registered?: Date
   formattedCitation?: string
   claims?: Claim[]
@@ -57,8 +57,8 @@ export type Work = WorkMetadata & {
   parts?: Works
   partOf?: Works
   otherRelated?: Works
+  allRelated?: Works
 }
-
 
 export type Works = {
   totalCount: number
@@ -72,8 +72,6 @@ export type Works = {
   nodes: Work[]
   personToWorkTypesMultilevel: MultilevelFacet[]
 }
-
-
 
 type Title = {
   title: string
@@ -96,7 +94,6 @@ export type Rights = {
   rightsUri: string
   rightsIdentifier: string
 }
-
 
 type Creator = {
   id: string
@@ -153,8 +150,6 @@ type UsageMonth = {
   total: number
 }
 
-
-
 // Organization types
 export type OrganizationMetadata = {
   name: string
@@ -179,7 +174,6 @@ export type Organization = OrganizationMetadata & {
   works: Works
 }
 
-
 export type Organizations = {
   totalCount: number
   pageInfo: PageInfo
@@ -187,8 +181,6 @@ export type Organizations = {
   countries: Facet[]
   nodes: Organization[]
 }
-
-
 
 type Geolocation = {
   pointLongitude: number
@@ -199,8 +191,6 @@ type OrganizationIdentifier = {
   identifier: string
   identifierType: string
 }
-
-
 
 // People types
 export type PersonMetadata = {
@@ -225,14 +215,12 @@ export interface Person extends PersonMetadata {
   works: PersonWorks
 }
 
-
 export interface People {
   __typename: String
   totalCount: number
   pageInfo: PageInfo
   nodes: Person[]
 }
-
 
 interface Link {
   name: string
@@ -252,8 +240,6 @@ interface PersonWorks extends Works {
   totalOpenLicenses: number
   openLicenseResourceTypes: Facet[]
 }
-
-
 
 // Repository types
 export type RepositoryMetadata = {
@@ -293,8 +279,6 @@ export interface Repositories {
   nodes: Repository[]
 }
 
-
-
 interface RepositoryWorks {
   totalCount: number
   languages: Facet[]
@@ -304,8 +288,6 @@ interface RepositoryWorks {
   licenses: Facet[]
   published: Facet[]
 }
-
-
 
 interface RepositoryFacet extends Facet {
   name: string
@@ -318,9 +300,6 @@ interface TextRestriction {
 type DefinedTerm = {
   name: string
 }
-
-
-
 
 // Shared types
 type Identifier = {


### PR DESCRIPTION
## Purpose
Display all related works (as exposed through events) as the default option

closes: datacite/datacite#2176

## Approach
Queries graphql for all related dois (regardless of specific relationship) and displays this as the default filter.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [x] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
