### PR TITLE
Fix for license image stretching

### DIFF
--- a/src/components/License/License.tsx
+++ b/src/components/License/License.tsx
@@ -1,6 +1,5 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import React from 'react'
-import Image from 'next/image'
 import {
   faCreativeCommons,
   faCreativeCommonsBy,
@@ -114,10 +113,8 @@ export const License: React.FunctionComponent<Props> = ({ rights = [] }) => {
           target="_blank"
           rel="noreferrer"
         >
-          <Image
+          <img 
             src={`https://img.shields.io/badge/license-${r.rightsIdentifier}-blue.svg`}
-            width={76}
-            height={20}
             alt='License badge'
           />
         </a>

--- a/src/styles.css
+++ b/src/styles.css
@@ -298,6 +298,11 @@ input[type=text] {
   margin-bottom: 3px;
 }
 
+.license img {
+  height: 20px;
+  margin-right: 3px;
+}
+
 .label {
   margin-top: 8px;
   margin-right: 3px;


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

closes: datacite/datacite#2192

## Approach
<!--- _How does this change address the problem?_ -->

Use \<img\> tag instead of NextJS \<Image\>, which has requirements around including height and width in some circumstances. 

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
