### PR TITLE
Disable Link prefetching across components

### DIFF
--- a/src/components/FacetList/FacetListItem.tsx
+++ b/src/components/FacetList/FacetListItem.tsx
@@ -56,7 +56,7 @@ export default function FacetListItem(props: Props) {
   return (
     <Row as="li" key={facet.id}>
       <Col xs={1} className={styles.checkbox}>
-        <Link href={url + params.toString()} className={"facet-" + param}>
+        <Link prefetch={false} href={url + params.toString()} className={"facet-" + param}>
           <FontAwesomeIcon icon={icon} />{' '}
         </Link>
       </Col>

--- a/src/components/OrganizationMetadata/OrganizationMetadata.tsx
+++ b/src/components/OrganizationMetadata/OrganizationMetadata.tsx
@@ -228,7 +228,7 @@ function TitleLink({ linkToExternal, id, name, alternateName, show }: TitleProps
 
   function LinkWrapper({ children }: PropsWithChildren) {
     if (!linkToExternal)
-      return <Link href={'/ror.org' + rorFromUrl(id)} className="fw-bold">{children}</Link>
+      return <Link prefetch={false} href={'/ror.org' + rorFromUrl(id)} className="fw-bold">{children}</Link>
 
     return <a target="_blank" rel="noreferrer" href={id}>{children}</a>
   }

--- a/src/components/PersonEmployment/PersonEmployment.tsx
+++ b/src/components/PersonEmployment/PersonEmployment.tsx
@@ -15,7 +15,7 @@ const PersonEmployment: React.FunctionComponent<Props> = ({ employment }) => {
 
     return (
       <h4 className="work">
-        <Link href={'/grid.ac' + gridFromUrl(employment.organizationId)}>
+        <Link prefetch={false} href={'/grid.ac' + gridFromUrl(employment.organizationId)}>
           {employment.organizationName}
         </Link>
       </h4>

--- a/src/components/RepositoryDetail/RepositoryDetail.tsx
+++ b/src/components/RepositoryDetail/RepositoryDetail.tsx
@@ -28,7 +28,7 @@ export function RepositorySidebar({ repo }: Props) {
           </Button>
         )}
         {repo.works && (repo.works.totalCount > 0) && (
-          <Link href={"/doi.org?query=client.uid:" + repo.clientId}>
+          <Link prefetch={false} href={"/doi.org?query=client.uid:" + repo.clientId}>
             <Button variant="primary" id="find-related">
               <FontAwesomeIcon icon={faNewspaper} />
               &nbsp;
@@ -208,5 +208,3 @@ export function RepositoryDetail({ repo }: Props) {
     </>
   )
 }
-
-

--- a/src/components/RepositoryMetadata/RepositoryMetadata.tsx
+++ b/src/components/RepositoryMetadata/RepositoryMetadata.tsx
@@ -75,9 +75,11 @@ function RepositoryMetadata({ repo }: Props) {
   return (
     <Row key={repo.id} className="panel panel-transparent">
       <Col className="panel-body">
-        <h3 className="fw-bold"><Link href={detailUrl()}>
-          {repo.name}
-        </Link></h3>
+        <h3 className="fw-bold">
+          <Link prefetch={false} href={detailUrl()}>
+            {repo.name}
+          </Link>
+        </h3>
         {description()}
         {tags()}
         {links()}

--- a/src/components/WorkFunding/WorkFunding.tsx
+++ b/src/components/WorkFunding/WorkFunding.tsx
@@ -20,7 +20,7 @@ const WorkFunding: React.FunctionComponent<Props> = ({ funding }) => {
     )
       return (
         <h4 className="work">
-          <Link href={'/doi.org' + doiFromUrl(funding.funderIdentifier)}>
+          <Link prefetch={false} href={'/doi.org' + doiFromUrl(funding.funderIdentifier)}>
             {funding.funderName}
           </Link>
         </h4>
@@ -37,7 +37,7 @@ const WorkFunding: React.FunctionComponent<Props> = ({ funding }) => {
       )}
       {showAwardLink && (
         <div className="award">
-          <Link href={'/doi.org' + doiFromUrl(funding.funderIdentifier || '') + '?query=fundingReferences.awardNumber:(' + funding.awardNumber + ')'}>
+          <Link prefetch={false} href={'/doi.org' + doiFromUrl(funding.funderIdentifier || '') + '?query=fundingReferences.awardNumber:(' + funding.awardNumber + ')'}>
             {funding.awardNumber}
           </Link>
         </div>

--- a/src/components/WorkMetadata/WorkMetadata.tsx
+++ b/src/components/WorkMetadata/WorkMetadata.tsx
@@ -123,7 +123,7 @@ export default function WorkMetadata({
       <div className="creators">
         {creatorList.map((c, index) =>
           c.id !== null ? (
-            <Link href={'/orcid.org' + c.id} key={index}>
+            <Link prefetch={false} href={'/orcid.org' + c.id} key={index}>
               {c.displayName}
             </Link>
           ) : (

--- a/src/components/WorkMetadata/WorkMetadata.tsx
+++ b/src/components/WorkMetadata/WorkMetadata.tsx
@@ -50,7 +50,7 @@ export default function WorkMetadata({
     if (!metadata.titles[0])
       return (
         <h3 className="work">
-          <Link href={'/doi.org/' + metadata.doi}>
+          <Link prefetch={false} href={'/doi.org/' + metadata.doi}>
             No Title
           </Link>
         </h3>
@@ -61,7 +61,7 @@ export default function WorkMetadata({
 
     return (
       <h3 className="work">
-        <Link href={'/doi.org/' + metadata.doi}>
+        <Link prefetch={false} href={'/doi.org/' + metadata.doi}>
           {ReactHtmlParser(sanitizedTitle)}
         </Link>
       </h3>

--- a/src/components/WorkPerson/WorkPerson.tsx
+++ b/src/components/WorkPerson/WorkPerson.tsx
@@ -32,7 +32,7 @@ const WorkPerson: React.FunctionComponent<Props> = ({ person }) => {
     return (
       <>
         <h4 className="work">
-          <Link href={'/orcid.org' + orcidFromUrl(person.id)}>
+          <Link prefetch={false} href={'/orcid.org' + orcidFromUrl(person.id)}>
             {name}
           </Link>
         </h4>
@@ -42,7 +42,7 @@ const WorkPerson: React.FunctionComponent<Props> = ({ person }) => {
               {person.affiliation?.map((item) =>
                 item.id ? (
                   <div className="affiliation" key={item.id}>
-                    <Link href={'/ror.org' + rorFromUrl(item.id)}>
+                    <Link prefetch={false} href={'/ror.org' + rorFromUrl(item.id)}>
                         {item.name}
                     </Link>
                   </div>
@@ -65,7 +65,7 @@ const WorkPerson: React.FunctionComponent<Props> = ({ person }) => {
     return (
       <>
         <h4 className="work">
-          <Link href={'/ror.org' + rorFromUrl(person.id)}>
+          <Link prefetch={false} href={'/ror.org' + rorFromUrl(person.id)}>
             {name}
           </Link>
         </h4>
@@ -75,7 +75,7 @@ const WorkPerson: React.FunctionComponent<Props> = ({ person }) => {
               {person.affiliation?.map((item) =>
                 item.id ? (
                   <div className="affiliation" key={item.id}>
-                    <Link href={'/ror.org' + rorFromUrl(item.id)}>
+                    <Link prefetch={false} href={'/ror.org' + rorFromUrl(item.id)}>
                         {item.name}
                     </Link>
                   </div>


### PR DESCRIPTION
## Purpose
Improve performance and user experience by disabling prefetching for Next.js Link components across various components.

## Approach
By adding `prefetch={false}` to all `<Link>` components in the project, we prevent unnecessary network requests and improve initial page load performance.

### Key Modifications
- Added `prefetch={false}` to `<Link>` components in the following files:
  - `FacetListItem.tsx`
  - `OrganizationMetadata.tsx`
  - `PersonEmployment.tsx`
  - `RepositoryDetail.tsx`
  - `RepositoryMetadata.tsx`
  - `WorkFunding.tsx`
  - `WorkMetadata.tsx`
  - `WorkPerson.tsx`

### Important Technical Details
- Next.js `prefetch` prop defaults to `true` for `<Link>` components, which can cause unnecessary network requests
- Disabling prefetching reduces initial page load time and bandwidth usage
- No functional changes to link behavior or routing

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
