### PR TITLE
Add null check for repoId in RepositoryDashboard

### DIFF
--- a/src/components/RepositoryDetail/RepositoryDashboard.tsx
+++ b/src/components/RepositoryDetail/RepositoryDashboard.tsx
@@ -26,6 +26,8 @@ interface Props {
 }
 
 export function RepositoryDashboard({ repoId }: Props) {
+  if (!repoId) return <></>
+
   const { data: repo, loading, error } = useRepositoryRelatedContent(repoId)
 
   if (loading) return <Row><Loading /></Row>


### PR DESCRIPTION
## Purpose
Add a null check for `repoId` in the RepositoryDashboard component to prevent rendering when no repository ID is provided.

## Approach
### Key Modifications
- Added an early return condition to prevent rendering when `repoId` is falsy (null, undefined, empty string)
- Ensures component gracefully handles cases with no repository ID

### Important Technical Details
- Simple null check prevents potential undefined errors
- Minimal change that improves component's robustness
- Prevents unnecessary API calls or rendering when no valid repository ID exists

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
