### PR TITLE
Fix: DOI query with quotes

### DIFF
--- a/src/data/queries/doiQuery.ts
+++ b/src/data/queries/doiQuery.ts
@@ -7,7 +7,7 @@ import fetchConditionalCache from 'src/utils/fetchConditionalCache'
 
 function buildDoiSearchParams(id: string): URLSearchParams {
   return new URLSearchParams({
-    query: 'uid:' + id,
+    query: `uid:"${id}"`,
     include: 'client',
     affiliation: 'false',
     publisher: 'true',


### PR DESCRIPTION
## Purpose
This PR updates the DOI query to correctly search for DOIs by wrapping the ID in quotes.

closes datacite/datacite/issues/2289

## Approach
The change modifies the `buildDoiSearchParams` function to include the DOI ID in quotes when constructing the query string. This ensures that the search accurately targets the specified DOI.

### Key Modifications
- Updated the `query` parameter in `buildDoiSearchParams` to wrap the DOI id in quotes: `query: \`uid:"${id}"\``

### Important Technical Details
- The change ensures that the DOI ID is treated as a literal string when querying the API. This is necessary for accurate matching.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
