### PR TITLE
Fix: Remove `cursor` parameter on facet selection

### DIFF
--- a/src/components/FacetList/FacetListItem.tsx
+++ b/src/components/FacetList/FacetListItem.tsx
@@ -51,6 +51,7 @@ export default function FacetListItem(props: Props) {
     // otherwise replace param with new value and use unchecked icon
     params.set(param, value)
   }
+  params.delete('cursor')
 
   return (
     <ListGroup.Item as="li" key={facet.id}>


### PR DESCRIPTION
## Purpose
This PR addresses an issue where the `cursor` parameter was not being removed when a facet was selected. This could lead to unexpected behavior when navigating through the facets.

closes: #471 

## Approach
The `cursor` parameter is deleted from the URLSearchParams in the `FacetListItem` component when a facet is selected. This ensures that the `cursor` parameter is not included in the URL when a facet is selected.

### Key Modifications
-   Added `params.delete('cursor')` to the `FacetListItem` component to remove the `cursor` parameter from the URLSearchParams.

### Important Technical Details
-   The `cursor` parameter is used for pagination. When a facet is selected, the pagination should reset. This change ensures that the cursor is reset.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
