### PR TITLE
Fix: Handle nullish subjects in extractFOS

### DIFF
--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -104,7 +104,7 @@ export function toBarRecord(data: Facet) {
 
 export function extractFOS(subjects: any) {
   const fos = subjects
-    .filter((s) => s.subject.startsWith('FOS: '))
+    .filter((s) => s.subject?.startsWith('FOS: '))
     .map(({ subject: s }) => ({ id: kebabify(s.slice(5)), name: s.slice(5) }))
 
   const uniqueFOS = Array.from(new Set(fos.map((f) => f.id))).map((id) =>


### PR DESCRIPTION
## Purpose
This pull request addresses an issue where the `extractFOS` function was failing due to potential null or undefine
d values in the `subject` property of the input `subjects` array. This was causing the `startsWith` method to throw an error.

## Approach
The fix involves adding a null check to ensure that the `subject` property exists before calling the `startsWith` 
method. This prevents the error and allows the function to correctly extract and process the FOS (Fields of Study) data.

### Key Modifications
- Added a null check `s.subject?.startsWith('FOS: ')` to the filter condition in the `extractFOS` function.

### Important Technical Details
- The null check uses the optional chaining operator (`?.`) to safely access the `startsWith` method only if `s.su
bject` is not null or undefined.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved data filtering to gracefully handle missing or undefined entries, preventing potential runtime issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->