### PR TITLE
remove find related works button

### DIFF
--- a/src/components/RepositoryDetail/RepositorySidebar.tsx
+++ b/src/components/RepositoryDetail/RepositorySidebar.tsx
@@ -38,22 +38,7 @@ export function RepositorySidebar({ repo }: Props) {
     </>
   }
 
-  function FindRelatedWorksButton() {
-    if (!repo.clientId) return null
-
-    return <Button variant="primary" href={"/doi.org?query=client.uid:" + repo.clientId} id="find-related">
-      <FontAwesomeIcon icon={faNewspaper} />
-      &nbsp;
-      Find Related Works
-    </Button>
-  }
-
-
   return <>
-    <div className="d-grid gap-2">
-      <FindRelatedWorksButton />
-    </div>
-
     <ContactList />
   </>
 }

--- a/src/components/RepositoryDetail/RepositorySidebar.tsx
+++ b/src/components/RepositoryDetail/RepositorySidebar.tsx
@@ -1,9 +1,6 @@
 import React from 'react'
 import Row from 'react-bootstrap/Row'
 import Col from 'react-bootstrap/Col'
-import Button from 'react-bootstrap/Button'
-import { faNewspaper } from '@fortawesome/free-solid-svg-icons'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
 import { Repository } from 'src/data/types';
 


### PR DESCRIPTION
## Purpose
Remove the *Find Related Works* button from the repository pages as it is now redundant

closes: _Add github issue that originated this PR_

## Approach
<!--- _How does this change address the problem?_ -->

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Removed the button previously provided for accessing related works.
	- The sidebar now directly displays the contact list, resulting in a streamlined interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->