### PR TITLE
Support ORCID IDs ending in X; link ORCIDs in Creators pane that aren't submitted as a full orcid.org link

### DIFF
--- a/src/components/PersonTable/PersonTable.tsx
+++ b/src/components/PersonTable/PersonTable.tsx
@@ -11,7 +11,7 @@ type Props = {
 
 const PersonTable: React.FunctionComponent<Props> = ({ people }) => {
   const personList = people.map((person) => {
-    const link = person.id && person.id.startsWith('https://orcid.org/0') ?
+    const link = person.id ?
       '/orcid.org/' + orcidFromUrl(person.id) : undefined;
     const personName = person.familyName ? [person.givenName, person.familyName].join(' ') : person.name
     const personLink = link ? <Link href={link}>{personName}</Link> : personName;

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -39,7 +39,7 @@ export const orcidFromUrl = (orcidInput: string) => {
     : orcidInput;
 
   // Validate the ORCID pattern (XXXX-XXXX-XXXX-XXXX)
-  const orcidPattern = /^\d{4}-\d{4}-\d{4}-\d{4}$/;
+  const orcidPattern = /^\d{4}-\d{4}-\d{4}-\d{3}[\dX]{1}$/;
 
   return orcidPattern.test(orcidId) ? orcidId : null;
 }


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

ORCIDs ending in X weren't linking due to a regex that didn't detect ORCIDs ending in X. The Creators pane on the Works page was only set up to detect ORCIDs in metadata that were submitted as complete links. This PR corrects these two issues. 

closes: _Add github issue that originated this PR_

## Approach
<!--- _How does this change address the problem?_ -->

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved ORCID validation to match the official ORCID format, ensuring more accurate recognition of valid IDs.
  - Broadened support for generating ORCID profile links, allowing links to be created for a wider range of valid ORCID IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->