### PR TITLE
Fix Vercel base URL logic for internal related works api calls

### DIFF
--- a/src/data/queries/relatedWorks.ts
+++ b/src/data/queries/relatedWorks.ts
@@ -5,19 +5,19 @@ import {
 
 function getBaseUrl(): string {
   const localhost = 'http://localhost:3000'
-  
+
   // Handle case when VERCEL_URL is defined
   if (process.env.VERCEL_URL) {
     if (process.env.VERCEL_URL === 'localhost:3000') {
       return localhost
     }
-    
+
     // Ensure URL has protocol
-    return process.env.VERCEL_URL.startsWith('http') 
-      ? process.env.VERCEL_URL 
+    return process.env.VERCEL_URL.startsWith('http')
+      ? process.env.VERCEL_URL
       : `https://${process.env.VERCEL_URL}`
   }
-  
+
   return localhost
 }
 
@@ -32,7 +32,6 @@ export async function getRelatedWorksGraph(doi: string): Promise<GraphData> {
     links: []
   }
   const baseUrl = getBaseUrl()
-  console.log("getRelatedWorksGraph", baseUrl, doi)
   try {
     const response = await fetch(`${baseUrl}/api/doi/related-graph/${doi}`)
     if (!response.ok) {

--- a/src/data/queries/relatedWorks.ts
+++ b/src/data/queries/relatedWorks.ts
@@ -5,12 +5,20 @@ import {
 
 function getBaseUrl(): string {
   const localhost = 'http://localhost:3000'
-    const baseUrl =
-    process.env.VERCEL_URL === 'localhost:3000'
-      ? localhost
-      : `https://${process.env.VERCEL_URL}`
-        if (process.env.VERCEL_URL) return baseUrl
+  
+  // Handle case when VERCEL_URL is defined
+  if (process.env.VERCEL_URL) {
+    if (process.env.VERCEL_URL === 'localhost:3000') {
       return localhost
+    }
+    
+    // Ensure URL has protocol
+    return process.env.VERCEL_URL.startsWith('http') 
+      ? process.env.VERCEL_URL 
+      : `https://${process.env.VERCEL_URL}`
+  }
+  
+  return localhost
 }
 
 export interface GraphData {

--- a/src/data/queries/relatedWorks.ts
+++ b/src/data/queries/relatedWorks.ts
@@ -2,13 +2,15 @@ import {
   ForceDirectedGraphNode,
   ForceDirectedGraphLink
 } from 'src/components/ForceDirectedGraph/ForceDirectedSpec'
-import { VERCEL_URL, URLS } from 'src/data/constants'
 
 function getBaseUrl(): string {
-  if (VERCEL_URL && VERCEL_URL !== 'localhost:3000')
-    return `https://${VERCEL_URL}`
-
-  return URLS.localhost
+  const localhost = 'http://localhost:3000'
+    const baseUrl =
+    process.env.VERCEL_URL === 'localhost:3000'
+      ? localhost
+      : `https://${process.env.VERCEL_URL}`
+        if (process.env.VERCEL_URL) return baseUrl
+      return localhost
 }
 
 export interface GraphData {
@@ -22,6 +24,7 @@ export async function getRelatedWorksGraph(doi: string): Promise<GraphData> {
     links: []
   }
   const baseUrl = getBaseUrl()
+  console.log("getRelatedWorksGraph", baseUrl, doi)
   try {
     const response = await fetch(`${baseUrl}/api/doi/related-graph/${doi}`)
     if (!response.ok) {


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->
This change refactors the way the application determines its base URL when making API calls, particularly in Vercel environments. Previously, the logic for `getBaseUrl` was not correctly handling the Vercel environment URL, potentially causing API calls to fail.

closes: https://github.com/datacite/datacite/issues/2322

## Approach
<!--- _How does this change address the problem?_ -->
The `getBaseUrl` function is updated to directly use `process.env.VERCEL_URL` and handle the `localhost:3000` case explicitly. This ensures the correct base URL is constructed for API requests regardless of whether the app is running locally or on a Vercel deployment.

### Key Modifications

*   Removed unnecessary imports `VERCEL_URL` and `URLS`.
*   Refactored `getBaseUrl` to use `process.env.VERCEL_URL` to determine the current environment's URL.
*   Improved logic to correctly identify `localhost:3000` and return the appropriate local URL.
*   Added a console log in `getRelatedWorksGraph` for debugging purposes (can be removed later if needed).

### Important Technical Details
The core change is in the `getBaseUrl` function, which now robustly determines the application's host URL by inspecting `process.env.VERCEL_URL`. This is crucial for server-side fetching (like in `getServerSideProps`) where relative paths are not sufficient for API calls back to the same application.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved handling of environment variables for base URL configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->