### PR TITLE
Add parentheses around organization query string so filters work correctly when building query string

### DIFF
--- a/src/data/queries/searchDoiQuery.ts
+++ b/src/data/queries/searchDoiQuery.ts
@@ -15,7 +15,7 @@ function buildOrgQuery(rorId: string | undefined, rorFundingIds: string[]): stri
   const id = 'ror.org/' + extractRORId(rorId)
   const urlId = `"https://${id}"`
   const rorFundingIdsQuery = rorFundingIds.map(id => '"https://doi.org/' + id + '"').join(' OR ')
-  return `(organization_id:${id} OR affiliation_id:${id} OR related_dmp_organization_id:${id} OR provider.ror_id:${urlId}) OR funding_references.funderIdentifier:(${urlId} ${rorFundingIdsQuery && `OR ${rorFundingIdsQuery}`})`
+  return `((organization_id:${id} OR affiliation_id:${id} OR related_dmp_organization_id:${id} OR provider.ror_id:${urlId}) OR funding_references.funderIdentifier:(${urlId} ${rorFundingIdsQuery && `OR ${rorFundingIdsQuery}`}))`
 }
 
 export function buildQuery(variables: QueryVar): string {


### PR DESCRIPTION

## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

The organization query string isn't currently bound by a parentheses, so the addition of filters, ex. `AND language=en`, produce unexpected results on Organization pages.

closes: _Add github issue that originated this PR_

## Approach
<!--- _How does this change address the problem?_ -->

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
