### PR TITLE
Configured toast embed with integrity checks

### DIFF
--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -66,7 +66,7 @@ export default async function RootLayout({ children }: PropsWithChildren) {
       <Script id="feedback-button">
         {`(function(){window.onUsersnapCXLoad=function(e){e.init()};var e=document.createElement("script");e.defer=1,e.src="https://widget.usersnap.com/global/load/b4393e90-ec13-4338-b299-7b6f122b7de3?onload=onUsersnapCXLoad",document.getElementsByTagName("head")[0].appendChild(e)})();`}
       </Script>
-      <Script id="datacite-toasts" data-site="commons" src="https://assets.datacite.org/javascripts/toast_notifications.js" async>
+      <Script id="datacite-toasts" data-site={IS_PROD ? "commons" : "commons-stage"} integrity="sha384-gUubuxXrs+7lydVlrDnvS1E8vcCLh6QxtugnduK104u5faiHKpzcsTJ9MG+AguAK" crossOrigin="anonymous" src="https://assets.datacite.org/javascripts/toast_notifications.js" async>
       </Script>
     </html>
   )

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -66,7 +66,7 @@ export default async function RootLayout({ children }: PropsWithChildren) {
       <Script id="feedback-button">
         {`(function(){window.onUsersnapCXLoad=function(e){e.init()};var e=document.createElement("script");e.defer=1,e.src="https://widget.usersnap.com/global/load/b4393e90-ec13-4338-b299-7b6f122b7de3?onload=onUsersnapCXLoad",document.getElementsByTagName("head")[0].appendChild(e)})();`}
       </Script>
-      <Script id="datacite-toasts" data-site={IS_PROD ? "commons" : "commons-stage"} integrity="sha384-gUubuxXrs+7lydVlrDnvS1E8vcCLh6QxtugnduK104u5faiHKpzcsTJ9MG+AguAK" crossOrigin="anonymous" src="https://assets.datacite.org/javascripts/toast_notifications.js" async>
+      <Script id="datacite-toasts" data-site={process.env.VERCEL_ENV === 'production' ? "commons" : "commons-stage"} integrity="sha384-gUubuxXrs+7lydVlrDnvS1E8vcCLh6QxtugnduK104u5faiHKpzcsTJ9MG+AguAK" crossOrigin="anonymous" src="https://assets.datacite.org/javascripts/toast_notifications.js" async>
       </Script>
     </html>
   )

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -66,7 +66,7 @@ export default async function RootLayout({ children }: PropsWithChildren) {
       <Script id="feedback-button">
         {`(function(){window.onUsersnapCXLoad=function(e){e.init()};var e=document.createElement("script");e.defer=1,e.src="https://widget.usersnap.com/global/load/b4393e90-ec13-4338-b299-7b6f122b7de3?onload=onUsersnapCXLoad",document.getElementsByTagName("head")[0].appendChild(e)})();`}
       </Script>
-      <Script id="datacite-toasts" data-site={process.env.VERCEL_ENV === 'production' ? "commons" : "commons-stage"} integrity="sha384-gUubuxXrs+7lydVlrDnvS1E8vcCLh6QxtugnduK104u5faiHKpzcsTJ9MG+AguAK" crossOrigin="anonymous" src="https://assets.datacite.org/javascripts/toast_notifications.js" async>
+      <Script id="datacite-toasts" data-site={process.env.VERCEL_ENV === 'production' ? "commons" : "commons-stage"} integrity="sha384-GcQ+0oaToUM4aiWhvr9TGxAqENo62EqS5oqGlWBooarQhVPVZCx80Uk+QWf6zVg1" crossOrigin="anonymous" src="https://assets.datacite.org/javascripts/toast_notifications.js" async>
       </Script>
     </html>
   )


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->

Loads the following script to display "Toast Notice" posts published in Wordpress: https://github.com/datacite/assets/blob/master/source/javascripts/toast_notifications.js Adds integrity checks and configures the `data-site` attribute based on the app environment so authored posts can be displayed in stage and/or production environments.

closes: _Add github issue that originated this PR_

## Approach
<!--- _How does this change address the problem?_ -->

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Made toast notification script environment-aware so notifications use production settings in live deployments and staging settings elsewhere.
  * Strengthened script security by adding integrity and cross-origin attributes to ensure resources load reliably and safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->