### PR TITLE
Add accessible names to icon-only links

### DIFF
--- a/src/components/Footer/Footer.test.tsx
+++ b/src/components/Footer/Footer.test.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import { mount } from '@cypress/react'
+import Footer from './Footer'
+
+describe('Footer Component', () => {
+  it('adds accessible names to social links', () => {
+    mount(<Footer />)
+
+    cy.get('a[aria-label="Email DataCite support"]').should('exist')
+    cy.get('a[aria-label="Visit the DataCite blog"]').should('exist')
+    cy.get('a[aria-label="Visit DataCite on GitHub"]').should('exist')
+    cy.get('a[aria-label="Visit DataCite on X"]').should('exist')
+    cy.get('a[aria-label="Visit DataCite on Mastodon"]').should('exist')
+    cy.get('a[aria-label="Visit DataCite on LinkedIn"]').should('exist')
+    cy.get('a[aria-label="Visit the DataCite YouTube channel"]').should('exist')
+  })
+})

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -38,32 +38,54 @@ export default function Footer() {
           </Col>
           <Col sm={3} md={3} className="footer-column">
             <h4 className="share">Contact Us</h4>
-            <a href="mailto:support@datacite.org" className="share">
-              <FontAwesomeIcon icon={faEnvelope} />
+            <a
+              href="mailto:support@datacite.org"
+              className="share"
+              aria-label="Email DataCite support"
+            >
+              <FontAwesomeIcon icon={faEnvelope} aria-hidden="true" />
             </a>
-            <a href="https://datacite.org/blog/" className="share">
-              <FontAwesomeIcon icon={faBlog} />
+            <a
+              href="https://datacite.org/blog/"
+              className="share"
+              aria-label="Visit the DataCite blog"
+            >
+              <FontAwesomeIcon icon={faBlog} aria-hidden="true" />
             </a>
-            <a href="https://github.com/datacite/datacite" className="share">
-              <FontAwesomeIcon icon={faGithub} />
+            <a
+              href="https://github.com/datacite/datacite"
+              className="share"
+              aria-label="Visit DataCite on GitHub"
+            >
+              <FontAwesomeIcon icon={faGithub} aria-hidden="true" />
             </a>
-            <a href="https://twitter.com/datacite" className="share">
+            <a
+              href="https://twitter.com/datacite"
+              className="share"
+              aria-label="Visit DataCite on X"
+            >
               <svg aria-hidden="true" focusable="false" data-prefix="fab" className="svg-inline--fa fa-twitter" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="currentColor" d="M389.2 48h70.6L305.6 224.2 487 464H345L233.7 318.6 106.5 464H35.8L200.7 275.5 26.8 48H172.4L272.9 180.9 389.2 48zM364.4 421.8h39.1L151.1 88h-42L364.4 421.8z"></path></svg>
             </a>
-            <a href="https://openbiblio.social/@datacite" className="share">
-              <FontAwesomeIcon icon={faMastodon} />
+            <a
+              href="https://openbiblio.social/@datacite"
+              className="share"
+              aria-label="Visit DataCite on Mastodon"
+            >
+              <FontAwesomeIcon icon={faMastodon} aria-hidden="true" />
             </a>
             <a
               href="https://www.linkedin.com/company/datacite"
               className="share"
+              aria-label="Visit DataCite on LinkedIn"
             >
-              <FontAwesomeIcon icon={faLinkedin} />
+              <FontAwesomeIcon icon={faLinkedin} aria-hidden="true" />
             </a>
             <a
               href="https://www.youtube.com/@DataCiteChannel"
               className="share"
+              aria-label="Visit the DataCite YouTube channel"
             >
-              <FontAwesomeIcon icon={faYoutube} />
+              <FontAwesomeIcon icon={faYoutube} aria-hidden="true" />
             </a>
             <Links links={LINKS.contact_links} />
             <StatusPage />

--- a/src/components/Header/Header.test.tsx
+++ b/src/components/Header/Header.test.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import { mount } from '@cypress/react'
+import Header from './Header'
+
+describe('Header Component', () => {
+  it('provides an accessible name for the home logo link', () => {
+    mount(<Header />)
+
+    cy.get('a[aria-label="DataCite Commons home"]')
+      .should('have.attr', 'href', '/')
+  })
+})

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -22,8 +22,8 @@ export default function Header() {
     <Container fluid>
       <Navbar expand="lg" className={`${styles.navbar} justify-content-between`}>
         <Brand>
-          <Link href="/">
-            <img src="/images/commons-logo.svg" height="50" className="commons-logo" />
+          <Link href="/" aria-label="DataCite Commons home">
+            <img src="/images/commons-logo.svg" height="50" className="commons-logo" alt="DataCite Commons" />
           </Link>
         </Brand>   
         <Toggle />

--- a/src/components/HelpIcon/HelpIcon.test.tsx
+++ b/src/components/HelpIcon/HelpIcon.test.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import { mount } from '@cypress/react'
+import HelpIcon from './HelpIcon'
+
+describe('HelpIcon Component', () => {
+  it('falls back to text-based link labels when linkLabel is blank', () => {
+    mount(
+      <HelpIcon
+        link="https://example.com/help"
+        text="Citation details"
+        linkLabel="   "
+        position='inline'
+      />
+    )
+
+    cy.get('a[aria-label="Open help: Citation details"]')
+      .should('have.attr', 'href', 'https://example.com/help')
+  })
+})

--- a/src/components/HelpIcon/HelpIcon.tsx
+++ b/src/components/HelpIcon/HelpIcon.tsx
@@ -9,21 +9,38 @@ import { faQuestionCircle } from '@fortawesome/free-regular-svg-icons'
 type Props = {
 	text?: string
 	link?: string
+	linkLabel?: string
 	size?: number
 	color?: string
 	position?: 'inline' | 'top-right'
 	padding?: number
 }
 
-const HelpIcon: React.FunctionComponent<Props> = ({ text = null, link = null, size = 24, color = 'gray', position = 'top-right', padding = 0 }) => {
+const HelpIcon: React.FunctionComponent<Props> = ({
+	text = null,
+	link = null,
+	linkLabel = null,
+	size = 24,
+	color = 'gray',
+	position = 'top-right',
+	padding = 0
+}) => {
 	if (text === null && link === null) return <></>;
 
 	const positionStyle: CSSProperties = position == 'top-right' ? { position: 'absolute', top: 0, right: padding } : {}
+	const accessibleLinkLabel = linkLabel ?? (text ? `Open help: ${text}` : 'Open help documentation')
 
 	function Icon() {
 		if (link !== null) return (
-			<a href={link} target="_blank" rel="noreferrer" className='help-icon' style={positionStyle}>
-				<FontAwesomeIcon icon={faQuestionCircle} fontSize={size} />
+			<a
+				href={link}
+				target="_blank"
+				rel="noreferrer"
+				className='help-icon'
+				style={positionStyle}
+				aria-label={accessibleLinkLabel}
+			>
+				<FontAwesomeIcon icon={faQuestionCircle} fontSize={size} aria-hidden="true" />
 			</a>
 		)
 

--- a/src/components/HelpIcon/HelpIcon.tsx
+++ b/src/components/HelpIcon/HelpIcon.tsx
@@ -28,7 +28,9 @@ const HelpIcon: React.FunctionComponent<Props> = ({
 	if (text === null && link === null) return <></>;
 
 	const positionStyle: CSSProperties = position == 'top-right' ? { position: 'absolute', top: 0, right: padding } : {}
-	const accessibleLinkLabel = linkLabel ?? (text ? `Open help: ${text}` : 'Open help documentation')
+	const accessibleLinkLabel = linkLabel?.trim().length
+		? linkLabel.trim()
+		: (text ? `Open help: ${text}` : 'Open help documentation')
 
 	function Icon() {
 		if (link !== null) return (

--- a/src/components/License/License.test.tsx
+++ b/src/components/License/License.test.tsx
@@ -31,4 +31,38 @@ describe('License Component', () => {
     cy.get('a[aria-label="View license details: Traditional Knowledge Notice"]')
       .should('exist')
   })
+
+  it('renders navigable links for other rights badges', () => {
+    mount(
+      <License
+        rights={[
+          {
+            rights: 'MIT License',
+            rightsUri: 'https://opensource.org/license/mit',
+            rightsIdentifier: 'mit-license'
+          }
+        ]}
+      />
+    )
+
+    cy.get('a[aria-label="View license details: MIT LICENSE"]')
+      .should('have.attr', 'href', 'https://opensource.org/license/mit')
+  })
+
+  it('does not crash on malformed percent-encoded other rights identifiers', () => {
+    mount(
+      <License
+        rights={[
+          {
+            rights: 'Bad License',
+            rightsUri: 'https://example.com/license',
+            rightsIdentifier: 'bad%zz-license'
+          }
+        ]}
+      />
+    )
+
+    cy.get('a[aria-label="View license details: BAD%ZZ%20LICENSE"]')
+      .should('have.attr', 'href', 'https://example.com/license')
+  })
 })

--- a/src/components/License/License.test.tsx
+++ b/src/components/License/License.test.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import { mount } from '@cypress/react'
+import { License } from './License'
+
+describe('License Component', () => {
+  it('adds accessible names to icon-only license links', () => {
+    mount(
+      <License
+        rights={[
+          {
+            rights: 'Creative Commons Attribution 4.0 International',
+            rightsUri: 'https://creativecommons.org/licenses/by/4.0/',
+            rightsIdentifier: 'cc-by-4.0'
+          },
+          {
+            rights: 'Traditional Knowledge Notice',
+            rightsUri: 'https://localcontexts.org/notice/tk-notice/',
+            rightsIdentifier: 'tk-notice',
+            rightsIdentifierScheme: 'Local Contexts'
+          }
+        ]}
+      />
+    )
+
+    cy.get('a[aria-label="View license details: Creative Commons"]')
+      .should('exist')
+
+    cy.get('a[aria-label="View license details: Creative Commons Attribution"]')
+      .should('exist')
+
+    cy.get('a[aria-label="View license details: Traditional Knowledge Notice"]')
+      .should('exist')
+  })
+})

--- a/src/components/License/License.tsx
+++ b/src/components/License/License.tsx
@@ -106,17 +106,27 @@ export const License: React.FunctionComponent<Props> = ({ rights = [] }) => {
     return sum
   }, [] as { rightsIdentifier: string }[])
 
+  const formatOtherRightsLabel = (rightsIdentifier: string) =>
+    decodeURIComponent(rightsIdentifier).replace(/\s+/g, ' ').trim()
+
   if (!ccRights[0] && !otherRights[0] && !localContextRights[0]) return null
 
   return (
     <div className={'license ' + styles.licenses}>
       {ccRights.map((r, index) => (
-        <a href={r.rightsUri} key={index} target="_blank" rel="noreferrer">
+        <a
+          href={r.rightsUri}
+          key={index}
+          target="_blank"
+          rel="noreferrer"
+          aria-label={`View license details: ${r.altText}`}
+        >
         <FontAwesomeIcon
           key={r.rightsIdentifier}
           icon={r.icon}
           className={styles.icons}
           title={r.altText}
+          aria-hidden="true"
         />
         </a>
       ))}
@@ -126,6 +136,7 @@ export const License: React.FunctionComponent<Props> = ({ rights = [] }) => {
           key={r.rightsIdentifier}
           target="_blank"
           rel="noreferrer"
+          aria-label={`View license details: ${r.altText}`}
         >
           <Image
             src={r.icon}
@@ -140,6 +151,7 @@ export const License: React.FunctionComponent<Props> = ({ rights = [] }) => {
           key={r.rightsIdentifier}
           target="_blank"
           rel="noreferrer"
+          aria-label={`View license details: ${formatOtherRightsLabel(r.rightsIdentifier)}`}
         >
           <img
             src={`https://img.shields.io/badge/license-${r.rightsIdentifier}-blue.svg`}

--- a/src/components/License/License.tsx
+++ b/src/components/License/License.tsx
@@ -92,7 +92,7 @@ export const License: React.FunctionComponent<Props> = ({ rights = [] }) => {
   }, [] as { icon: any, rightsUri: string, altText: string, rightsIdentifier: string }[])
 
   const otherRights = uniqueRights.reduce((sum, r) => {
-    const ri = { rightsIdentifier: '' }
+    const ri = { rightsIdentifier: '', rightsUri: '' }
     if (r.rightsIdentifier && !isCreativeCommons(r) && !isLocalContexts(r)) {
       if (r.rightsIdentifier.startsWith('apache')) {
         ri.rightsIdentifier = 'Apache%202.0'
@@ -101,13 +101,23 @@ export const License: React.FunctionComponent<Props> = ({ rights = [] }) => {
           .replace(/-/g, '%20')
           .toUpperCase()
       }
+      ri.rightsUri = r.rightsUri
       sum.push(ri)
     }
     return sum
-  }, [] as { rightsIdentifier: string }[])
+  }, [] as { rightsIdentifier: string, rightsUri: string }[])
 
-  const formatOtherRightsLabel = (rightsIdentifier: string) =>
-    decodeURIComponent(rightsIdentifier).replace(/\s+/g, ' ').trim()
+  const formatOtherRightsLabel = (rightsIdentifier: string) => {
+    let decodedIdentifier = rightsIdentifier
+
+    try {
+      decodedIdentifier = decodeURIComponent(rightsIdentifier)
+    } catch {
+      decodedIdentifier = rightsIdentifier
+    }
+
+    return decodedIdentifier.replace(/\s+/g, ' ').trim()
+  }
 
   if (!ccRights[0] && !otherRights[0] && !localContextRights[0]) return null
 
@@ -122,7 +132,6 @@ export const License: React.FunctionComponent<Props> = ({ rights = [] }) => {
           aria-label={`View license details: ${r.altText}`}
         >
         <FontAwesomeIcon
-          key={r.rightsIdentifier}
           icon={r.icon}
           className={styles.icons}
           title={r.altText}
@@ -148,6 +157,7 @@ export const License: React.FunctionComponent<Props> = ({ rights = [] }) => {
       ))}
       {otherRights.map((r) => (
         <a
+          href={r.rightsUri}
           key={r.rightsIdentifier}
           target="_blank"
           rel="noreferrer"

--- a/src/components/MetricsDisplay/MetricsDisplay.test.tsx
+++ b/src/components/MetricsDisplay/MetricsDisplay.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import { mount } from '@cypress/react'
+import { MetricsDisplay } from './MetricsDisplay'
+
+describe('MetricsDisplay Component', () => {
+  it('adds accessible names to metric help links', () => {
+    mount(
+      <MetricsDisplay
+        counts={{ citations: 33, views: 1200 }}
+        links={{
+          citations: 'https://support.datacite.org/docs/citations-and-references',
+          views: 'https://support.datacite.org/docs/views-and-downloads'
+        }}
+      />
+    )
+
+    cy.get('a[aria-label="Learn more about citations metrics"]')
+      .should('have.attr', 'href', 'https://support.datacite.org/docs/citations-and-references')
+    cy.get('a[aria-label="Learn more about views metrics"]')
+      .should('have.attr', 'href', 'https://support.datacite.org/docs/views-and-downloads')
+  })
+})

--- a/src/components/MetricsDisplay/MetricsDisplay.tsx
+++ b/src/components/MetricsDisplay/MetricsDisplay.tsx
@@ -49,7 +49,15 @@ export function MetricsDisplay({ counts, links = {} }: Props) {
   const metricList = metricsData.filter(metric => metric.count && metric.count > 0).map((metric, index) =>
     <React.Fragment key={"metric-" + index}>
       <dd>{compactNumbers(metric.count || 0)}</dd>
-      <dt>{metric.label} <HelpIcon link={metric.link} size={20} position='inline' /></dt>
+      <dt>
+        {metric.label}{' '}
+        <HelpIcon
+          link={metric.link}
+          linkLabel={`Learn more about ${metric.label.toLowerCase()} metrics`}
+          size={20}
+          position='inline'
+        />
+      </dt>
     </React.Fragment>
   )
   return (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add accessible names to shared footer social/contact icon links without changing their visuals
- label the shared header logo link, metric help links, and license icon links while keeping the icon markup decorative
- fix follow-up review issues in `HelpIcon` and `License` by handling blank `linkLabel` values, preserving `rightsUri` for `otherRights`, adding `href` to those links, removing the redundant inner icon key, and safely decoding custom rights labels
- add focused component coverage for the updated footer, header, metrics, help icon, and license link names

## Testing
- `yarn eslint src/components/HelpIcon/HelpIcon.tsx src/components/HelpIcon/HelpIcon.test.tsx src/components/License/License.tsx src/components/License/License.test.tsx`
- `yarn build`

## Notes
- `yarn type-check` is still blocked by pre-existing unrelated test issues in `src/components/PersonMetadata/PersonMetadata.test.tsx` and `src/components/VerticalBarChart/VerticalBarChart.test.tsx`.
- Earlier Lighthouse verification for the main routes (`/`, `/doi.org`, `/orcid.org`, `/ror.org`) still stands, and these follow-up fixes tighten edge cases in the same accessibility surface area.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a493a2d6-8b70-4762-b524-0ff0dac4f547"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a493a2d6-8b70-4762-b524-0ff0dac4f547"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added component tests for Footer, Header, License, MetricsDisplay, and HelpIcon verifying link targets and accessible naming.

* **Bug Fixes**
  * Improved accessibility and link behavior: added descriptive aria-labels and alt text, treated decorative icons as such, and ensured help/metric links expose clear, readable labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->