### PR TITLE
Address CodeRabbit accessibility feedback from PR #593

### DIFF
--- a/src/components/DataCiteButton/DataCiteButton.tsx
+++ b/src/components/DataCiteButton/DataCiteButton.tsx
@@ -16,7 +16,7 @@ interface Props extends ButtonProps {
 
 const COLORS = {
   primary: '#037AAD',
-  secondary: '#243b54',
+  secondary: 'var(--datacite-color-primary, #243b54)',
 }
 
 export default function DataCiteButton(props: Props) {

--- a/src/components/FilterItem/FilterItem.tsx
+++ b/src/components/FilterItem/FilterItem.tsx
@@ -44,6 +44,7 @@ const FilterItem: React.FunctionComponent<Props> = ({
         type="button"
         className={`facet-${name} btn btn-link p-0 border-0 bg-transparent`}
         aria-label={filterActionLabel}
+        aria-pressed={isActive}
         onClick={() => toggleFilter(id)}
       >
         {activeIcon(id)}

--- a/src/components/Header/Search.tsx
+++ b/src/components/Header/Search.tsx
@@ -30,12 +30,12 @@ export default function Search() {
   }, [searchParams])
 
   function search(query: string) {
-    const params = new URLSearchParams(searchParams || {});
+    const params = new URLSearchParams(searchParams || {})
 
-    if (searchInput) params.set('query', query);
-    else params.delete('query');
+    if (query) params.set('query', query)
+    else params.delete('query')
 
-    router.push(`${base}?${params.toString()}`);
+    router.push(`${base}?${params.toString()}`)
   }
 
   return (

--- a/src/components/SearchBox/SearchBox.tsx
+++ b/src/components/SearchBox/SearchBox.tsx
@@ -58,14 +58,16 @@ export default function SearchBox({ path, placeholder = 'Type to search...' }: P
         <FontAwesomeIcon icon={faSearch} />
       </Button>
       {searchInput !== '' && (
-        <span
+        <button
           id="search-clear-facets"
-          title="Clear"
-          aria-label="Clear"
+          type="button"
+          title="Clear search input"
+          aria-label="Clear search input"
+          className="p-0 border-0 bg-transparent"
           onClick={onSearchClear}
         >
           <FontAwesomeIcon icon={faTimes} />
-        </span>
+        </button>
       )}
     </InputGroup>
   </>)

--- a/src/styles.css
+++ b/src/styles.css
@@ -228,8 +228,16 @@ a.navbar-brand {
   right: 60px;
   top: 10px;
   font-size: 16px;
-  text-decoration: none;
   cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+}
+
+#search-clear-facets:focus-visible {
+  outline: 2px solid #037aad;
+  outline-offset: 2px;
 }
 
 .search-submit-facets {
@@ -688,7 +696,8 @@ body {
   --datacite-color-primary: #243b54;
 }
 
-.button:hover {
+.button:hover,
+.button:focus-visible {
     background-color: #0071b2;
     color: #fff;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to [PR #593](https://github.com/datacite/akita/pull/593), implementing the actionable [CodeRabbit](https://github.com/datacite/akita/pull/593#issuecomment) review items.

## Changes

- **SearchBox**: Replaced the facet search clear control (`#search-clear-facets`) with a native `button` (`type="button"`) so it is focusable and keyboard-operable; kept the same id for styling; clarified `title` / `aria-label` to "Clear search input"; adjusted global CSS for button layout and `:focus-visible` outline.
- **Header Search**: Fixed `search(query)` to use the **passed-in** `query` when setting or removing the `query` URL parameter, so clearing the field removes `query` from the URL instead of leaving `?query=`.
- **FilterItem**: Added `aria-pressed={isActive}` on the filter toggle for correct toggle semantics.
- **DataCiteButton**: Set secondary color to `var(--datacite-color-primary, #243b54)` so it tracks the global CSS variable.
- **styles.css**: Extended `.button:hover` with `.button:focus-visible` for equivalent keyboard focus styling.

## Testing

- ESLint on touched TSX files passes.
- Full `yarn type-check` currently fails on pre-existing test file issues unrelated to this change.

## Base branch

Targets `accessibility` so these fixes can merge into the same line of work as PR #593.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fc898edc-0cac-456f-b2b0-91b4fca67ac3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc898edc-0cac-456f-b2b0-91b4fca67ac3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

