### PR TITLE
Add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+Akita is the web frontend for [DataCite Commons](https://commons.datacite.org). It consists of:
+- **Next.js frontend** (port 3000) — the main React/TypeScript app
+- **Flask API backend** (port 5328) — Python microservice for related-works graph data
+
+### Running services
+
+- `yarn dev` — starts only the Next.js frontend
+- `yarn dev-all` — starts both Next.js and Flask API via `concurrently`
+- `yarn api` — starts only the Flask API (uses `uv` to sync and run)
+
+The Flask API requires `uv` to be installed (`~/.local/bin/uv`). The `yarn api` command handles `uv sync --project api` automatically before starting Flask.
+
+### Environment
+
+Copy `.env.example` to `.env` before first run. All external APIs (DataCite, ORCID, ROR) default to staging endpoints — no secrets are required for basic development.
+
+### Lint / Type-check / Test
+
+- `yarn lint` — ESLint (pre-existing errors in `cypress.config.ts`, not blocking)
+- `yarn type-check` — TypeScript compiler (pre-existing errors in test files, not blocking)
+- `yarn cy:run` — Cypress E2E tests in headless mode (requires dev server on port 3000)
+- `yarn cy:open` — Cypress interactive mode
+
+### Notes
+
+- `uv` must be on PATH (`export PATH="$HOME/.local/bin:$PATH"`) for `yarn api` / `yarn dev-all` to work.
+- The app fetches all data from external staging APIs at runtime — no local database needed.
+- `yarn build` produces a production build; `yarn dev` is preferred for development.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with development environment instructions for Cursor Cloud agents, covering:

- Service overview (Next.js frontend + Flask API backend)
- How to run services (`yarn dev`, `yarn dev-all`, `yarn api`)
- Environment setup (`.env.example` → `.env`, staging API defaults)
- Lint/type-check/test commands
- Key caveats (`uv` must be on PATH, no local database needed)

## Demo

[demo_search_and_doi_detail.mp4](https://cursor.com/agents/bc-b8529046-9b4f-4d8f-bd7b-fa628a8b54c3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_search_and_doi_detail.mp4)

Searching for "ocean warming" and viewing a DOI detail page on the locally running dev server.

[DataCite Commons homepage](https://cursor.com/agents/bc-b8529046-9b4f-4d8f-bd7b-fa628a8b54c3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage.webp)
[Search results for climate change](https://cursor.com/agents/bc-b8529046-9b4f-4d8f-bd7b-fa628a8b54c3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsearch_results.webp)

## Verification

- `yarn install` — dependencies installed successfully
- `yarn lint` — ESLint runs (pre-existing errors in repo)
- `yarn type-check` — TypeScript check runs (pre-existing errors in repo)
- `yarn build` — production build succeeds
- `yarn dev-all` — both Next.js (port 3000) and Flask API (port 5328) start and respond
- `yarn cy:run` — Cypress E2E tests pass (about, search, server specs verified)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b8529046-9b4f-4d8f-bd7b-fa628a8b54c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b8529046-9b4f-4d8f-bd7b-fa628a8b54c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

