### PR TITLE
Fix GridID test flakiness using network fixtures and test-ids

### DIFF
--- a/cypress/e2e/OrganizationContainerMissingGridID.test.ts
+++ b/cypress/e2e/OrganizationContainerMissingGridID.test.ts
@@ -1,18 +1,29 @@
-describe('OrganizationContainer Display GridID if it exists', () => {
+describe('Organization page GRID identifier', () => {
   beforeEach(() => {
     cy.setCookie('_consent', 'true')
+    cy.intercept('GET', '/providers', {}).as('getProviders')
   })
-  it('visit site with gridID, id element should exist', () => {
+  it('shows the GRID identifier when organization has a GRID id', () => {
+    cy.intercept('GET', '**/api/ror/v2/organizations/052gg0110*', {
+      fixture: 'ror/organization-052gg0110.json',
+    }).as('getOrgWithGrid')
     cy.visit('/ror.org/052gg0110')
+    cy.get('#ror-link', { timeout: 10000 })
+      .should('have.attr', 'href', 'https://ror.org/052gg0110')
     cy
-      .get('.identifier').first()
-      .should('include.text','GRID')
+      .get('[data-testid="grid-identifier"]')
+      .should('contain.text', 'GRID')
   })
-  it('visit site without gridID, id element not should exist', () => {
+  it('does not show the GRID identifier when organization has no GRID id', () => {
+    cy.intercept('GET', '**/api/ror/v2/organizations/02hhf2525*', {
+      fixture: 'ror/organization-02hhf2525.json',
+    }).as('getOrgWithoutGrid')
     cy.visit('/ror.org/02hhf2525')
-    cy
-      .get('.identifier')
-      .should('not.include.text','GRID')
+    cy.get('#ror-link', { timeout: 10000 })
+      .should('have.attr', 'href', 'https://ror.org/02hhf2525')
+    cy.get('body')
+      .find('[data-testid="grid-identifier"]')
+      .should('not.exist')
   })
 })
 

--- a/src/components/OrganizationMetadata/OrganizationMetadata.tsx
+++ b/src/components/OrganizationMetadata/OrganizationMetadata.tsx
@@ -93,7 +93,7 @@ export default function OrganizationMetadata({
           <h5 className="m-0 fw-bold">Other Identifiers</h5>
         </Col></Row>
         {grid.length > 0 && (
-          <Row className="identifier id-type-grid"><Col>
+          <Row className="identifier id-type-grid" data-testid="grid-identifier"><Col>
             GRID{' '}{grid[0].identifier}
           </Col></Row>
         )}


### PR DESCRIPTION
## Purpose

The primary goal of this PR is to resolve the flakiness observed in the GridID end-to-end tests. Previously, these tests would fail intermittently (30-50% of the time) due to reliance on live API responses. This PR introduces network interception and fixtures to ensure consistent and reliable test outcomes.

## Approach

- **Mocking API Responses**: Implemented `cy.intercept` to catch ROR API calls and return local JSON fixtures. This removes dependency on external network conditions and live data changes.
- **Improved Selectors**: Added a `data-testid` attribute to the GRID identifier component to make the tests more resilient to CSS changes and improve targeting accuracy.
- **Enhanced Assertions**: Updated tests to explicitly check for the presence or absence of the GRID identifier based on the mocked data provided.

### Key Modifications

- **Tests**:
    - Updated `OrganizationContainerMissingGridID.test.ts` to use `cy.intercept` with fixtures (`ror/organization-052gg0110.json` and `ror/organization-02hhf2525.json`).
    - Renamed test descriptions for better clarity.
    - Updated selectors from generic classes (`.identifier`) to specific test IDs (`[data-testid="grid-identifier"]`).
- **Components**:
    - Modified `OrganizationMetadata.tsx` to include `data-testid="grid-identifier"` on the Row containing the GRID information.

### Important Technical Details

- Added a timeout and assertion for `#ror-link` to ensure the page has loaded sufficiently before checking for identifier elements.
- Included an intercept for `/providers` in `beforeEach` to prevent noise/errors during organization page loads.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for GRID identifier behavior on the organization page with improved assertions and API call stubbing.
  * Added test attribute to organization metadata component for better test selectability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->