### PR TITLE
Refactor: Use self-managed Vercel deployment in GitHub Actions

### DIFF
--- a/.github/workflows/cypress_tests.yml
+++ b/.github/workflows/cypress_tests.yml
@@ -21,13 +21,13 @@ jobs:
       matrix:
         containers: [1, 2, 3, 4, 5]
     steps:
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Cypress run
-        uses: cypress-io/github-action@v6
+        uses: cypress-io/github-action@v7
         with:
           build: yarn build
           start: yarn start

--- a/.github/workflows/cypress_tests.yml
+++ b/.github/workflows/cypress_tests.yml
@@ -12,6 +12,8 @@ on:
         required: true
       CYPRESS_USER_COOKIE:
         required: true
+permissions:
+  contents: read
 
 jobs:
   cypress:
@@ -19,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        containers: [1, 2, 3, 4, 5]
+        containers: [1, 2, 3, 4, 5, 6]
     steps:
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,18 +9,10 @@ jobs:
     secrets: inherit
   deploy:
     needs: test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Vercel deploy
-        uses: amondnet/vercel-action@v25.2.0
-        with:
-          vercel-token: ${{ secrets.VERCEL_TOKEN }}
-          vercel-org-id: ${{ secrets.ORG_ID}}
-          vercel-project-id: ${{ secrets.PROJECT_ID}}
-          scope: ${{ secrets.TEAM_ID}}
-          vercel-project-name: 'akita'
-          alias-domains: |
-            commons.datacite.vercel.app
-            commons.stage.datacite.org
+    uses: ./.github/workflows/vercel_deploy.yml
+    with:
+      production: false
+      aliases: |
+        commons.datacite.vercel.app
+        commons.stage.datacite.org
+    secrets: inherit

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -7,15 +7,7 @@ jobs:
     secrets: inherit
   deploy:
     needs: test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Vercel deploy
-        uses: amondnet/vercel-action@v25.2.0
-        with:
-          vercel-token: ${{ secrets.VERCEL_TOKEN }}
-          vercel-org-id: ${{ secrets.ORG_ID}}
-          vercel-project-id: ${{ secrets.PROJECT_ID}}
-          scope: ${{ secrets.TEAM_ID}}
-          vercel-project-name: 'akita'
+    uses: ./.github/workflows/vercel_deploy.yml
+    with:
+      production: false
+    secrets: inherit

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -10,17 +10,9 @@ jobs:
   deploy:
     if: github.actor != 'dependabot[bot]'
     needs: test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Vercel deploy
-        uses: amondnet/vercel-action@v25.2.0
-        with:
-          vercel-token: ${{ secrets.VERCEL_TOKEN }}
-          vercel-org-id: ${{ secrets.ORG_ID}}
-          vercel-project-id: ${{ secrets.PROJECT_ID}}
-          scope: ${{ secrets.TEAM_ID}}
-          vercel-project-name: 'akita'
-          alias-domains: |
-             commons-pr-{{PR_NUMBER}}.datacite.vercel.app
+    uses: ./.github/workflows/vercel_deploy.yml
+    with:
+      production: false
+      aliases: |
+        commons-pr-${{ github.event.pull_request.number }}.datacite.vercel.app
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,16 +8,7 @@ jobs:
     secrets: inherit
   release:
     needs: test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Vercel deploy
-        uses: amondnet/vercel-action@v25.2.0
-        with:
-          vercel-token: ${{ secrets.VERCEL_TOKEN }}
-          vercel-org-id: ${{ secrets.ORG_ID}}
-          vercel-project-id: ${{ secrets.PROJECT_ID}}
-          vercel-args: '--prod'
-          scope: ${{ secrets.TEAM_ID}}
-          vercel-project-name: 'akita'
+    uses: ./.github/workflows/vercel_deploy.yml
+    with:
+      production: true
+    secrets: inherit

--- a/.github/workflows/vercel_deploy.yml
+++ b/.github/workflows/vercel_deploy.yml
@@ -38,9 +38,9 @@ jobs:
         run: |
           set -euo pipefail
           if [[ "${{ inputs.production }}" == "true" ]]; then
-            DEPLOYMENT_URL=$(vercel deploy --prod --scope="$TEAM_ID" --yes)
+            DEPLOYMENT_URL=$(vercel deploy --prod --token="$VERCEL_TOKEN" --scope="$TEAM_ID" --yes)
           else
-            DEPLOYMENT_URL=$(vercel deploy --scope="$TEAM_ID" --yes)
+            DEPLOYMENT_URL=$(vercel deploy --token="$VERCEL_TOKEN" --scope="$TEAM_ID" --yes)
           fi
           echo "deployment_url=$DEPLOYMENT_URL" >> "$GITHUB_OUTPUT"
 
@@ -55,6 +55,6 @@ jobs:
           set -euo pipefail
           while IFS= read -r alias; do
             if [[ -n "$alias" ]]; then
-              vercel alias set "$DEPLOYMENT_URL" "$alias" --scope="$TEAM_ID"
+              vercel alias set "$DEPLOYMENT_URL" "$alias" --token="$VERCEL_TOKEN" --scope="$TEAM_ID"
             fi
           done <<< "$ALIASES"

--- a/.github/workflows/vercel_deploy.yml
+++ b/.github/workflows/vercel_deploy.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install Vercel CLI
         env:
-          VERCEL_CLI_VERSION: ">=47.2.2 <48"
+          VERCEL_CLI_VERSION: "latest"
         run: npm i -g "vercel@${VERCEL_CLI_VERSION}"
 
       - name: Vercel deploy

--- a/.github/workflows/vercel_deploy.yml
+++ b/.github/workflows/vercel_deploy.yml
@@ -11,6 +11,9 @@ on:
         type: string
         default: ""
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/vercel_deploy.yml
+++ b/.github/workflows/vercel_deploy.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install Vercel CLI
         env:
-          VERCEL_CLI_VERSION: "^47"
+          VERCEL_CLI_VERSION: ">=47.2.2 <48"
         run: npm i -g "vercel@${VERCEL_CLI_VERSION}"
 
       - name: Vercel deploy

--- a/.github/workflows/vercel_deploy.yml
+++ b/.github/workflows/vercel_deploy.yml
@@ -1,0 +1,60 @@
+name: Vercel Deploy (Reusable)
+on:
+  workflow_call:
+    inputs:
+      production:
+        required: false
+        type: boolean
+        default: false
+      aliases:
+        required: false
+        type: string
+        default: ""
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - name: Install Vercel CLI
+        env:
+          VERCEL_CLI_VERSION: "^47"
+        run: npm i -g "vercel@${VERCEL_CLI_VERSION}"
+
+      - name: Vercel deploy
+        id: vercel_deploy
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.PROJECT_ID }}
+          TEAM_ID: ${{ secrets.TEAM_ID }}
+        run: |
+          set -euo pipefail
+          if [[ "${{ inputs.production }}" == "true" ]]; then
+            DEPLOYMENT_URL=$(vercel deploy --prod --scope="$TEAM_ID" --yes)
+          else
+            DEPLOYMENT_URL=$(vercel deploy --scope="$TEAM_ID" --yes)
+          fi
+          echo "deployment_url=$DEPLOYMENT_URL" >> "$GITHUB_OUTPUT"
+
+      - name: Set aliases
+        if: ${{ inputs.aliases != '' }}
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          TEAM_ID: ${{ secrets.TEAM_ID }}
+          DEPLOYMENT_URL: ${{ steps.vercel_deploy.outputs.deployment_url }}
+          ALIASES: ${{ inputs.aliases }}
+        run: |
+          set -euo pipefail
+          while IFS= read -r alias; do
+            if [[ -n "$alias" ]]; then
+              vercel alias set "$DEPLOYMENT_URL" "$alias" --scope="$TEAM_ID"
+            fi
+          done <<< "$ALIASES"

--- a/.github/workflows/vercel_deploy.yml
+++ b/.github/workflows/vercel_deploy.yml
@@ -10,6 +10,15 @@ on:
         required: false
         type: string
         default: ""
+    secrets:
+      VERCEL_TOKEN:
+        required: true
+      ORG_ID:
+        required: true
+      PROJECT_ID:
+        required: true
+      TEAM_ID:
+        required: true
 
 permissions:
   contents: read


### PR DESCRIPTION
## Purpose

This PR updates the GitHub Actions workflows to use a self-managed Vercel deployment strategy. Previously, an outdated Vercel deployment action was used, which can no longer be maintained. This change introduces a reusable workflow (`vercel_deploy.yml`) that encapsulates the Vercel deployment logic, ensuring a more robust and maintainable deployment process.

## Approach

The core of this change involves replacing direct invocations of the `amondnet/vercel-action` with calls to a new, custom reusable workflow. This reusable workflow handles the Vercel CLI installation and deployment, offering more control and flexibility. Additionally, several GitHub Actions workflows (`cypress_tests.yml`, `deploy.yml`, `manual.yml`, `pull_request.yml`, `release.yml`) have been updated to utilize this new reusable workflow.

### Key Modifications

*   **Introduced `vercel_deploy.yml`:** A new reusable workflow that manages Vercel CLI installation and deployment.
*   **Refactored Deployment Workflows:** `deploy.yml`, `manual.yml`, `pull_request.yml`, and `release.yml` now use the `vercel_deploy.yml` workflow.
*   **Updated Action Versions:** Several GitHub Actions within `cypress_tests.yml` have been updated to their latest versions (e.g., `actions/setup-node@v6`, `actions/checkout@v6`, `cypress-io/github-action@v7`).
*   **Removed `amondnet/vercel-action`:** This action is no longer used across any workflows.

### Important Technical Details

*   The `vercel_deploy.yml` workflow now directly installs the Vercel CLI using `npm i -g "vercel@${VERCEL_CLI_VERSION}"`.
*   Deployment commands in `vercel_deploy.yml` use `vercel deploy --prod` for production deployments and `vercel deploy` for others, with the `--yes` flag to skip confirmations.
*   Alias management is now handled within `vercel_deploy.yml` using `vercel alias set`.
*   Environment variables for Vercel authentication (`VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`, `TEAM_ID`) are passed as secrets to the reusable workflow.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI actions to newer versions and granted repository read permissions for workflows.
  * Expanded Cypress test matrix to include an additional container instance.
* **Chores / New Features**
  * Centralized deployments into a reusable deployment workflow, with support for production/preview flags and configurable aliasing; workflows now inherit secrets for deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->