### PR TITLE
Fix: Update PersonMetadata and VerticalBarChart tests

### DIFF
--- a/src/components/PersonMetadata/PersonMetadata.test.tsx
+++ b/src/components/PersonMetadata/PersonMetadata.test.tsx
@@ -12,7 +12,7 @@ describe('Person Metadata Component', () => {
   })
 
   it('orcid', () => {
-    mount(<PersonMetadata metadata={data} />)
+    mount(<PersonMetadata metadata={data} url={'orcid.org/?'} />)
     cy.get('a#orcid-link')
       .contains('orcid.org/0000-0001-6528-2027')
       .should('be.visible')
@@ -32,7 +32,7 @@ describe('Person Metadata Component', () => {
   // })
 
   it('name', () => {
-    mount(<PersonMetadata metadata={data} />)
+    mount(<PersonMetadata metadata={data} url={'orcid.org/?'} />)
     cy.get('h3.work').contains('Juan Perez').should('be.visible')
   })
 

--- a/src/components/VerticalBarChart/VerticalBarChart.test.tsx
+++ b/src/components/VerticalBarChart/VerticalBarChart.test.tsx
@@ -1,7 +1,7 @@
 /// <reference types="cypress" />
 
 import React from 'react'
-import { mount } from 'cypress-react-unit-test'
+import { mount } from '@cypress/react'
 import VerticalBarChart from './VerticalBarChart'
 
 const data = {


### PR DESCRIPTION
## Purpose

This PR updates the testing setup for the `PersonMetadata` and `VerticalBarChart` components.

## Approach

The primary changes involve updating the import path for the `mount` function in `VerticalBarChart.test.tsx` and passing a `url` prop to the `PersonMetadata` component in its tests.

### Key Modifications

*   **VerticalBarChart.test.tsx:** Changed the import for `mount` from `cypress-react-unit-test` to `@cypress/react`.
*   **PersonMetadata.test.tsx:** Modified the `mount` calls to include a `url={'orcid.org/?'}` prop for the `PersonMetadata` component.

### Important Technical Details

*   The change in `VerticalBarChart.test.tsx` reflects a potential migration or update to the recommended way of mounting React components within Cypress tests.
*   Passing the `url` prop to `PersonMetadata` in its tests ensures that the ORCID link is rendered correctly and can be tested against the expected format.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.