### PR TITLE
Refactor crossrefFunderQuery to use ROR v2 client directly

### DIFF
--- a/cypressFetchMock.cjs
+++ b/cypressFetchMock.cjs
@@ -110,8 +110,39 @@ async function tryMockResponse(input, init) {
       if (id === '013meh722') {
         return jsonResponse(readFixtureJson('ror', 'organization-013meh722.json'))
       }
+      if (id === '0472cxd90') {
+        return jsonResponse({
+          id: 'https://ror.org/0472cxd90',
+          names: [{ lang: 'en', types: ['ror_display', 'label'], value: 'European Research Council' }],
+          status: 'active',
+          established: 2007,
+          locations: [],
+          types: ['funder', 'government'],
+          links: [{ type: 'website', value: 'https://erc.europa.eu' }],
+          external_ids: [],
+          relationships: [],
+        })
+      }
     }
     if (url.pathname === '/v2/organizations') {
+      const rawAdvancedQ = url.searchParams.get('query.advanced') || ''
+      const advancedQ = decodeQueryParam(rawAdvancedQ)
+      if (advancedQ === 'external_ids.all:100011199') {
+        return jsonResponse({
+          number_of_results: 1,
+          time_taken: 1,
+          items: [{ id: 'https://ror.org/0472cxd90' }],
+          meta: { types: [], countries: [], continents: [], statuses: [] },
+        })
+      }
+      if (advancedQ === 'external_ids.all:100011105') {
+        return jsonResponse({
+          number_of_results: 0,
+          time_taken: 0,
+          items: [],
+          meta: { types: [], countries: [], continents: [], statuses: [] },
+        })
+      }
       const rawQ = url.searchParams.get('query') || ''
       const q = decodeQueryParam(rawQ)
       if (q === 'oxford') {
@@ -150,15 +181,6 @@ async function tryMockResponse(input, init) {
       return null
     }
 
-    if (variables.crossrefFunderId === '10.13039/100011199') {
-      return jsonResponse({ data: { organization: { id: 'https://ror.org/0472cxd90' } } })
-    }
-    if (variables.crossrefFunderId === '10.13039/100011105') {
-      return jsonResponse({
-        errors: [{ message: 'Record not found', path: ['organization'] }],
-        data: null,
-      })
-    }
     return null
   }
 

--- a/src/data/clients/ror-v2-client.ts
+++ b/src/data/clients/ror-v2-client.ts
@@ -107,6 +107,7 @@ export interface RORV2ClientConfig {
  */
 export interface RORV2SearchParams {
   query?: string;
+  queryAdvanced?: string;
   page?: number;
   types?: string | string[];
   countries?: string | string[];
@@ -199,7 +200,9 @@ export class RORV2Client {
   public async searchOrganizations(params: RORV2SearchParams = {}): Promise<RORV2SearchResponse> {
     const searchParams = new URLSearchParams();
 
-    if (params.query) {
+    if (params.queryAdvanced) {
+      searchParams.append('query.advanced', params.queryAdvanced);
+    } else if (params.query) {
       searchParams.append('query', params.query);
     }
 

--- a/src/data/queries/crossrefFunderQuery.ts
+++ b/src/data/queries/crossrefFunderQuery.ts
@@ -1,20 +1,17 @@
-import { gql } from '@apollo/client'
-import apolloClient from 'src/utils/apolloClient/apolloClient'
+import { RORV2Client } from 'src/data/clients/ror-v2-client'
+
+const rorClient = new RORV2Client()
+const FUNDREF_PREFIX = '10.13039/'
 
 export async function fetchCrossrefFunder(crossrefFunderId: string) {
-  const { data } = await apolloClient.query({
-    query: CROSSREF_FUNDER_GQL,
-    variables: { crossrefFunderId },
-    errorPolicy: 'all'
+  const fundrefId = crossrefFunderId.startsWith(FUNDREF_PREFIX)
+    ? crossrefFunderId.slice(FUNDREF_PREFIX.length)
+    : crossrefFunderId
+
+  const response = await rorClient.searchOrganizations({
+    queryAdvanced: `external_ids.all:${fundrefId}`,
   })
 
-  return { data }
+  const rorId = response.items[0]?.id ?? null
+  return { data: rorId ? { organization: { id: rorId } } : null }
 }
-
-export const CROSSREF_FUNDER_GQL = gql`
-  query getOrganizationQuery($crossrefFunderId: ID) {
-    organization(crossrefFunderId: $crossrefFunderId) {
-      id
-    }
-  }
-`


### PR DESCRIPTION
## Purpose

This PR refactors the `crossrefFunderQuery` to directly use the ROR v2 client instead of relying on Apollo Client. This change aims to simplify the data fetching logic and improve performance by removing an unnecessary layer of abstraction.

## Approach

The `crossrefFunderQuery` has been modified to directly call the `RORV2Client.searchOrganizations` method. This method now supports an `queryAdvanced` parameter, allowing for more specific searches. The mock responses in `cypressFetchMock.cjs` have been updated to reflect these changes in how organization searches are performed.

### Key Modifications

- Modified `crossrefFunderQuery.ts` to use `RORV2Client` directly.
- Added support for `queryAdvanced` parameter in `RORV2ClientConfig` and `RORV2SearchParams`.
- Updated `cypressFetchMock.cjs` to mock responses for advanced ROR v2 organization searches.
- Removed the Apollo GraphQL query related to fetching organization by `crossrefFunderId`.

### Important Technical Details

- The `fetchCrossrefFunder` function now constructs an advanced query using the `external_ids.all` parameter to search for organizations by their FundRef ID.
- The `RORV2Client` can now accept `queryAdvanced` as a search parameter, which is used to pass the advanced query string to the ROR v2 API.
- Mock responses in `cypressFetchMock.cjs` are updated to return specific ROR IDs based on the provided advanced query parameters.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for advanced search queries when searching ROR organizations.

* **Refactor**
  * Improved Crossref funder lookup mechanism for more direct and efficient data retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->