### PR TITLE
feat: Configure uv to exclude newer packages

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -10,3 +10,6 @@ dependencies = [
 
 [tool.uv.sources]
 datacitekit = { url = "https://github.com/datacite/datacitekit/archive/main.zip" }
+
+[tool.uv]
+exclude-newer = "7 days"

--- a/api/uv.lock
+++ b/api/uv.lock
@@ -2,6 +2,10 @@ version = 1
 revision = 3
 requires-python = ">=3.12"
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P7D"
+
 [[package]]
 name = "api"
 version = "0.1.0"
@@ -210,11 +214,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.14"
+version = "3.16"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/05/b1/efac073e0c297ecf2fb33c346989a529d4e19164f1759102dee5953ee17e/idna-3.14.tar.gz", hash = "sha256:466d810d7a2cc1022bea9b037c39728d51ae7dad40d480fc9b7d7ecf98ba8ee3", size = 198272, upload-time = "2026-05-10T20:32:15.935Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/88/bcf9709822fe69d02c2a6a77956c98ce6ea8ca8767a9aadcedc7eb6a2390/idna-3.16.tar.gz", hash = "sha256:d7a6da03db833450fca25d2358ac9ff06cd624577a4aea3a596d5c0f77b8e03d", size = 203770, upload-time = "2026-05-22T00:16:18.781Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/3c/3f62dee257eb3d6b2c1ef2a09d36d9793c7111156a73b5654d2c2305e5ce/idna-3.14-py3-none-any.whl", hash = "sha256:e677eaf072e290f7b725f9acf0b3a2bd55f9fd6f7c70abe5f0e34823d0accf69", size = 72184, upload-time = "2026-05-10T20:32:14.295Z" },
+    { url = "https://files.pythonhosted.org/packages/94/16/70255075a9859a0e3adb789b68ceb0e210dec03934245fd98d248226572f/idna-3.16-py3-none-any.whl", hash = "sha256:cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5", size = 74165, upload-time = "2026-05-22T00:16:16.698Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Purpose

This PR updates the `uv` dependency management tool to exclude newer packages.

## Approach

The `pyproject.toml` file has been updated to configure `uv` to exclude packages newer than 7 days. The `uv.lock` file has also been updated to reflect this change and include the latest version of the `idna` package.

### Key Modifications

*   **`pyproject.toml`**: Added `exclude-newer = "7 days"` to the `[tool.uv]` section.
*   **`uv.lock`**:
    *   Added `exclude-newer-span = "P7D"` to the `[options]` section.
    *   Updated the `idna` package from version "3.14" to "3.16".

### Important Technical Details

The `exclude-newer` configuration in `pyproject.toml` and `uv.lock` ensures that `uv` will not consider packages that are too new, potentially preventing issues with unstable or untested releases. The update to `idna` is a minor version bump, likely containing bug fixes or minor improvements.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build tool configuration to restrict dependency versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->