### PR TITLE
Fix race condition in Header search input and refactor Cypress search tests

### DIFF
--- a/cypress/e2e/search.test.ts
+++ b/cypress/e2e/search.test.ts
@@ -75,10 +75,7 @@ describe('Search', () => {
 
       it('search with click', () => {
         cy.visit('/doi.org/10.17863/cam.10544')
-        cy.get('#works-link')
-          .click()
-          .get('input[name="query"]')
-          .type('climate')
+        cy.typeHeaderSearchAfterNav('#works-link', '/doi.org', 'climate')
         cy.get('.search-submit').click()
         cy.get('#search-nav .active', { timeout: 15000 })
           .should('contain', 'Works')
@@ -260,10 +257,7 @@ describe('Search', () => {
 
       it('search with click', () => {
         cy.visit('/ror.org/013meh722')
-        cy.get('#organizations-link')
-          .click()
-          .get('input[name="query"]')
-          .type('Cambridge')
+        cy.typeHeaderSearchAfterNav('#organizations-link', '/ror.org', 'Cambridge')
         cy.get('.search-submit').click()
         cy.get('#search-nav .active', { timeout: 15000 })
           .should('contain', 'Organizations')

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,25 +1,9 @@
-// ***********************************************
-// This example commands.js shows you how to
-// create various custom commands and overwrite
-// existing commands.
-//
-// For more comprehensive examples of custom
-// commands please read more here:
-// https://on.cypress.io/custom-commands
-// ***********************************************
-//
-//
-// -- This is a parent command --
-// Cypress.Commands.add("login", (email, password) => { ... })
-//
-//
-// -- This is a child command --
-// Cypress.Commands.add("drag", { prevSubject: 'element'}, (subject, options) => { ... })
-//
-//
-// -- This is a dual command --
-// Cypress.Commands.add("dismiss", { prevSubject: 'optional'}, (subject, options) => { ... })
-//
-//
-// -- This will overwrite an existing command --
-// Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
+Cypress.Commands.add('typeHeaderSearchAfterNav', (navSelector, expectedPathname, query) => {
+  cy.get(navSelector).click()
+  cy.location('pathname').should('eq', expectedPathname)
+  cy.get('input[name="query"]')
+    .should('be.visible')
+    .clear()
+    .type(query)
+    .should('have.value', query)
+})

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -1,4 +1,5 @@
 const registerApiMocks = require('./registerApiMocks')
+require('./commands')
 
 beforeEach(() => {
   registerApiMocks()

--- a/src/components/Header/Search.tsx
+++ b/src/components/Header/Search.tsx
@@ -20,14 +20,14 @@ export default function Search() {
   const router = useRouter()
 
   const [searchInput, setSearchInput] = useState(searchParams?.get('query')?.toString() || '')
+  const [isFocused, setIsFocused] = useState(false)
 
-  // Update searchInput when URL changes (e.g., back button)
+  // Update searchInput when URL changes (e.g., back button), but not while typing
   React.useEffect(() => {
+    if (isFocused) return
     const queryParam = searchParams?.get('query')?.toString() || ''
-    if (searchInput !== queryParam) {
-      setSearchInput(queryParam)
-    }
-  }, [searchParams])
+    setSearchInput((current) => (current !== queryParam ? queryParam : current))
+  }, [searchParams, isFocused])
 
   function search(query: string) {
     const params = new URLSearchParams(searchParams || {})
@@ -48,6 +48,8 @@ export default function Search() {
         onChange={e => {
           setSearchInput(e.target.value)
         }}
+        onFocus={() => setIsFocused(true)}
+        onBlur={() => setIsFocused(false)}
         key="searchInput"
         className={`form-control ${styles.input}`}
         type="text"


### PR DESCRIPTION
## Purpose
Fix a race condition in the `Header` search input where URL-driven state updates could overwrite the user’s typed query while the input was focused. Also refactor the related end-to-end search tests to use a single, more reliable custom Cypress command.

## Approach

### Key Modifications
- **`src/components/Header/Search.tsx`**
  - Added an `isFocused` state to the search input.
  - Updated the URL query-param `useEffect` to skip resetting `searchInput` while the input is focused, preventing user input from being overwritten mid-typing.
  - Added `onFocus` / `onBlur` handlers to track focus state.
- **`cypress/support/commands.js`**
  - Replaced the default boilerplate with a new custom command: `typeHeaderSearchAfterNav`.
  - The command clicks a navigation element, waits for the expected pathname, ensures the query input is visible, clears it, types the query, and asserts the typed value.
- **`cypress/support/e2e.ts`**
  - Imported `./commands` so the custom command is registered for all specs.
- **`cypress/e2e/search.test.ts`**
  - Replaced the repeated manual click/type sequences in the Works and Organizations search tests with the new `typeHeaderSearchAfterNav` command.

### Important Technical Details
- The `useEffect` guarding logic relies on the component’s `isFocused` state, which is updated synchronously with focus/blur events. This ensures back-button and route-based query updates still work when the user is not actively typing.
- The custom Cypress command uses `cy.location('pathname').should('eq', expectedPathname)` to avoid timing issues caused by navigation, and `cy.get(...).should('be.visible')` before typing to reduce test flakiness.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored search test workflows to use a custom Cypress helper for improved test maintainability and consistency.

* **Bug Fixes**
  * Enhanced search input field to preserve user-typed content when navigating between pages while actively focused.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->