### PR TITLE
Fix metadata string handling and lazy-load chart components for better performance

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
   // Migrate to @cypress/webpack-dev-server v4 + webpack 5 (or Vite) before using `cypress open --component`.
   component: {
     setupNodeEvents(on, config) { },
-    specPattern: 'src/components/**/*.test.*',
+    specPattern: 'src/{components,utils}/**/*.test.*',
     devServer: {
       bundler: 'webpack',
       framework: 'react',

--- a/src/app/(main)/doi.org/[...doi]/RelatedAggregateGraph.tsx
+++ b/src/app/(main)/doi.org/[...doi]/RelatedAggregateGraph.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import Container from 'react-bootstrap/Container'
 import Col from 'react-bootstrap/Col'
 import { GraphData, getRelatedWorksGraph } from 'src/data/queries/relatedWorks'
-import ForceDirectedGraph from 'src/components/ForceDirectedGraph/ForceDirectedGraph'
+import LazyForceDirectedGraph from 'src/components/ForceDirectedGraph/LazyForceDirectedGraph'
 import EmptyChart from 'src/components/EmptyChart/EmptyChart'
 import styles from "./RelatedAggregateGraph.module.scss"
 
@@ -52,7 +52,7 @@ export default async function RelatedAggregateGraph(props: Props) {
 
   let innerGraph = <EmptyChart title={emptyTitleText} />
   if (graphExists) {
-    innerGraph = <ForceDirectedGraph
+    innerGraph = <LazyForceDirectedGraph
       titleText={titleText}
       nodes={data.nodes}
       links={data.links}

--- a/src/components/ForceDirectedGraph/LazyForceDirectedGraph.tsx
+++ b/src/components/ForceDirectedGraph/LazyForceDirectedGraph.tsx
@@ -1,0 +1,25 @@
+'use client'
+
+import React from 'react'
+import dynamic from 'next/dynamic'
+import EmptyChart from 'src/components/EmptyChart/EmptyChart'
+import type { ForceDirectedGraphLink, ForceDirectedGraphNode } from './ForceDirectedSpec'
+
+export type LazyForceDirectedGraphProps = {
+  titleText: string | string[]
+  nodes: ForceDirectedGraphNode[]
+  links: ForceDirectedGraphLink[]
+  range?: string[]
+  domain?: string[]
+  tooltipText?: string
+  isEmbed?: boolean
+}
+
+const ForceDirectedGraph = dynamic(() => import('./ForceDirectedGraph'), {
+  ssr: false,
+  loading: () => <EmptyChart title="Loading connections…" />,
+})
+
+export default function LazyForceDirectedGraph(props: LazyForceDirectedGraphProps) {
+  return <ForceDirectedGraph {...props} />
+}

--- a/src/components/MetadataTable/MetadataTable.tsx
+++ b/src/components/MetadataTable/MetadataTable.tsx
@@ -4,7 +4,7 @@ import Row from 'react-bootstrap/Row'
 import { Tab, Tabs } from 'src/components/ReactBootstrap'
 
 import { Work } from 'src/data/types'
-import { truncate, chunk, startCase } from 'src/utils/helpers'
+import { asHtmlString, truncate, chunk, startCase } from 'src/utils/helpers'
 import ReactHtmlParser from 'html-react-parser'
 import sanitizeHtml from 'sanitize-html'
 import WorkFunding from 'src/components/WorkFunding/WorkFunding'
@@ -23,7 +23,8 @@ type MetadataType = typeof METADATA_TYPES[number]
 export default function MetadataTable({ metadata }: Props) {
   const description = (title, key) => {
     if (!metadata.descriptions || !metadata.descriptions[0]) return ''
-    const rawDescription = metadata.descriptions[0].description
+    const rawDescription = asHtmlString(metadata.descriptions[0].description)
+    if (!rawDescription) return ''
 
     const truncatedDescription = truncate(rawDescription, {
       length: 2500,

--- a/src/components/MetadataTable/MetadataTable.tsx
+++ b/src/components/MetadataTable/MetadataTable.tsx
@@ -4,7 +4,7 @@ import Row from 'react-bootstrap/Row'
 import { Tab, Tabs } from 'src/components/ReactBootstrap'
 
 import { Work } from 'src/data/types'
-import { asHtmlString, truncate, chunk, startCase } from 'src/utils/helpers'
+import { truncate, chunk, startCase } from 'src/utils/helpers'
 import ReactHtmlParser from 'html-react-parser'
 import sanitizeHtml from 'sanitize-html'
 import WorkFunding from 'src/components/WorkFunding/WorkFunding'
@@ -23,7 +23,7 @@ type MetadataType = typeof METADATA_TYPES[number]
 export default function MetadataTable({ metadata }: Props) {
   const description = (title, key) => {
     if (!metadata.descriptions || !metadata.descriptions[0]) return ''
-    const rawDescription = asHtmlString(metadata.descriptions[0].description)
+    const rawDescription = metadata.descriptions[0].description
     if (!rawDescription) return ''
 
     const truncatedDescription = truncate(rawDescription, {

--- a/src/components/SankeyGraph/SankeyGraph.tsx
+++ b/src/components/SankeyGraph/SankeyGraph.tsx
@@ -5,52 +5,14 @@ import { Vega } from 'react-vega'
 
 import HelpIcon from '../HelpIcon/HelpIcon'
 import EmptyChart from '../EmptyChart/EmptyChart'
-import { MultilevelFacet } from 'src/data/types';
 import sankeySpec, { SankeyGraphData } from './SankeySpec'
 
 import styles from './SankeyGraph.module.scss'
-
 
 type Props = {
   titleText: string
   data: SankeyGraphData[]
   tooltipText?: string
-}
-
-
-export function multilevelToSankey(facets: MultilevelFacet[] | undefined): SankeyGraphData[] {
-  if (!facets) return []
-  const outerMap = new Map<SankeyGraphData['data'][0], Map<SankeyGraphData['data'][1], SankeyGraphData['count']>>();
-  facets = facets.filter(f => f.title)
-
-  facets.forEach(facet => {
-    facet.inner.forEach(i => {
-      const outerKey = facet.title
-      const innerKey = i.title
-      const count = i.count
-
-      let innerMap = outerMap.get(outerKey)
-
-      if (!innerMap) {
-        innerMap = new Map<SankeyGraphData['data'][1], SankeyGraphData['count']>()
-        outerMap.set(outerKey, innerMap)
-      }
-
-      const previousCount = innerMap.get(innerKey) || 0
-      const totalCount = count + previousCount
-      innerMap.set(innerKey, totalCount)
-    })
-  })
-
-  const data: SankeyGraphData[] = []
-
-  outerMap.forEach((innerMap, outerKey) => {
-    innerMap.forEach((count, innerKey) => {
-      data.push({ data: [outerKey, innerKey], count })
-    })
-  })
-
-  return data
 }
 
 

--- a/src/components/SankeyGraph/sankeyUtils.ts
+++ b/src/components/SankeyGraph/sankeyUtils.ts
@@ -1,0 +1,37 @@
+import { MultilevelFacet } from 'src/data/types'
+import type { SankeyGraphData } from './SankeySpec'
+
+export function multilevelToSankey(facets: MultilevelFacet[] | undefined): SankeyGraphData[] {
+  if (!facets) return []
+  const outerMap = new Map<SankeyGraphData['data'][0], Map<SankeyGraphData['data'][1], SankeyGraphData['count']>>()
+  facets = facets.filter(f => f.title)
+
+  facets.forEach(facet => {
+    facet.inner.forEach(i => {
+      const outerKey = facet.title
+      const innerKey = i.title
+      const count = i.count
+
+      let innerMap = outerMap.get(outerKey)
+
+      if (!innerMap) {
+        innerMap = new Map<SankeyGraphData['data'][1], SankeyGraphData['count']>()
+        outerMap.set(outerKey, innerMap)
+      }
+
+      const previousCount = innerMap.get(innerKey) || 0
+      const totalCount = count + previousCount
+      innerMap.set(innerKey, totalCount)
+    })
+  })
+
+  const data: SankeyGraphData[] = []
+
+  outerMap.forEach((innerMap, outerKey) => {
+    innerMap.forEach((count, innerKey) => {
+      data.push({ data: [outerKey, innerKey], count })
+    })
+  })
+
+  return data
+}

--- a/src/components/Work/AnalyticsBar.tsx
+++ b/src/components/Work/AnalyticsBar.tsx
@@ -1,15 +1,24 @@
+'use client'
+
 import React from 'react'
+import dynamic from 'next/dynamic'
 import { Tabs, Tab } from 'src/components/ReactBootstrap'
-import UsageChart from 'src/components/UsageChart/UsageChart'
 
 import { pluralize } from 'src/utils/helpers'
 import type { Work } from 'src/data/types'
 
+const UsageChart = dynamic(() => import('src/components/UsageChart/UsageChart'), {
+  ssr: false,
+  loading: () => (
+    <div className="usage-chart panel-body">
+      <p className="text-muted mb-0">Loading chart…</p>
+    </div>
+  ),
+})
 
 interface Props {
   doi: Work
 }
-
 
 export default function AnalyticsBar({ doi }: Props) {
   const views = doi.viewCount || 0

--- a/src/components/WorkMetadata/WorkMetadata.tsx
+++ b/src/components/WorkMetadata/WorkMetadata.tsx
@@ -8,7 +8,7 @@ import Badge from 'react-bootstrap/Badge'
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger'
 import Tooltip from 'react-bootstrap/Tooltip'
 
-import { startCase, truncate, orcidFromUrl } from 'src/utils/helpers'
+import { asHtmlString, startCase, truncate, orcidFromUrl } from 'src/utils/helpers'
 import ReactHtmlParser from 'html-react-parser'
 import sanitizeHtml from 'sanitize-html'
 import Link from 'next/link'
@@ -56,7 +56,16 @@ export default function WorkMetadata({
         </h3>
       )
 
-    const titleHtml = metadata.titles[0].title
+    const titleHtml = asHtmlString(metadata.titles[0].title)
+    if (!titleHtml) {
+      return (
+        <h3 className="work">
+          <Link prefetch={false} href={'/doi.org/' + metadata.doi}>
+            No Title
+          </Link>
+        </h3>
+      )
+    }
     const sanitizedTitle = sanitizeHtml(titleHtml)
 
     return (
@@ -71,7 +80,8 @@ export default function WorkMetadata({
   const externalTitle = () => {
     if (!metadata.titles[0]) return <h3 className="member">No Title</h3>
 
-    const titleHtml = metadata.titles[0].title
+    const titleHtml = asHtmlString(metadata.titles[0].title)
+    if (!titleHtml) return <h3 className="member">No Title</h3>
     const sanitizedTitle = sanitizeHtml(titleHtml)
 
     return (
@@ -190,10 +200,14 @@ export default function WorkMetadata({
   const description = () => {
     if (!metadata.descriptions || !metadata.descriptions[0]) return ''
 
-    const descriptionHtml = truncate(metadata.descriptions[0].description, {
-      length: 2500,
-      separator: '… '
-    })
+    const descriptionHtml = truncate(
+      asHtmlString(metadata.descriptions[0].description),
+      {
+        length: 2500,
+        separator: '… '
+      }
+    )
+    if (!descriptionHtml) return ''
 
     const sanitizedDescription = sanitizeHtml(descriptionHtml)
     const parsedDescription = ReactHtmlParser(sanitizedDescription)

--- a/src/components/WorkMetadata/WorkMetadata.tsx
+++ b/src/components/WorkMetadata/WorkMetadata.tsx
@@ -8,7 +8,7 @@ import Badge from 'react-bootstrap/Badge'
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger'
 import Tooltip from 'react-bootstrap/Tooltip'
 
-import { asHtmlString, startCase, truncate, orcidFromUrl } from 'src/utils/helpers'
+import { startCase, truncate, orcidFromUrl } from 'src/utils/helpers'
 import ReactHtmlParser from 'html-react-parser'
 import sanitizeHtml from 'sanitize-html'
 import Link from 'next/link'
@@ -56,7 +56,7 @@ export default function WorkMetadata({
         </h3>
       )
 
-    const titleHtml = asHtmlString(metadata.titles[0].title)
+    const titleHtml = metadata.titles[0].title
     if (!titleHtml) {
       return (
         <h3 className="work">
@@ -80,7 +80,7 @@ export default function WorkMetadata({
   const externalTitle = () => {
     if (!metadata.titles[0]) return <h3 className="member">No Title</h3>
 
-    const titleHtml = asHtmlString(metadata.titles[0].title)
+    const titleHtml = metadata.titles[0].title
     if (!titleHtml) return <h3 className="member">No Title</h3>
     const sanitizedTitle = sanitizeHtml(titleHtml)
 
@@ -201,7 +201,7 @@ export default function WorkMetadata({
     if (!metadata.descriptions || !metadata.descriptions[0]) return ''
 
     const descriptionHtml = truncate(
-      asHtmlString(metadata.descriptions[0].description),
+      metadata.descriptions[0].description,
       {
         length: 2500,
         separator: '… '

--- a/src/components/WorksListing/WorksListing.tsx
+++ b/src/components/WorksListing/WorksListing.tsx
@@ -16,8 +16,8 @@ import Pager from 'src/components/Pager/Pager'
 import type { ShowCharts } from 'src/components/WorksDashboard/WorksDashboard'
 import { multilevelToSankey } from 'src/components/SankeyGraph/sankeyUtils'
 
-const WorksDashboard = dynamic(() => import('src/components/WorksDashboard/WorksDashboard'))
-const SankeyGraph = dynamic(() => import('src/components/SankeyGraph/SankeyGraph'))
+const WorksDashboard = dynamic(() => import('src/components/WorksDashboard/WorksDashboard'), { ssr: false })
+const SankeyGraph = dynamic(() => import('src/components/SankeyGraph/SankeyGraph'), { ssr: false })
 
 interface Props {
   works: Works

--- a/src/components/WorksListing/WorksListing.tsx
+++ b/src/components/WorksListing/WorksListing.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import React from 'react'
+import dynamic from 'next/dynamic'
 import Row from 'react-bootstrap/Row'
 import Col from 'react-bootstrap/Col'
 
@@ -12,8 +13,11 @@ import LoadingFacetList from 'src/components/Loading/LoadingFacetList'
 import NoResults from 'src/components/NoResults/NoResults'
 
 import Pager from 'src/components/Pager/Pager'
-import WorksDashboard, { ShowCharts } from 'src/components/WorksDashboard/WorksDashboard'
-import SankeyGraph, { multilevelToSankey } from 'src/components/SankeyGraph/SankeyGraph'
+import type { ShowCharts } from 'src/components/WorksDashboard/WorksDashboard'
+import { multilevelToSankey } from 'src/components/SankeyGraph/sankeyUtils'
+
+const WorksDashboard = dynamic(() => import('src/components/WorksDashboard/WorksDashboard'))
+const SankeyGraph = dynamic(() => import('src/components/SankeyGraph/SankeyGraph'))
 
 interface Props {
   works: Works

--- a/src/utils/helpers.normalizeTextField.test.ts
+++ b/src/utils/helpers.normalizeTextField.test.ts
@@ -1,0 +1,31 @@
+/// <reference types="cypress" />
+
+import { normalizeTextField } from 'src/utils/helpers'
+
+describe('normalizeTextField', () => {
+  it('returns plain strings unchanged', () => {
+    expect(normalizeTextField('Example title')).to.eq('Example title')
+  })
+
+  it('returns empty string for null and undefined', () => {
+    expect(normalizeTextField(null)).to.eq('')
+    expect(normalizeTextField(undefined)).to.eq('')
+  })
+
+  it('joins string arrays and skips null, non-strings, and empty strings', () => {
+    expect(
+      normalizeTextField([
+        'First paragraph.',
+        null,
+        '',
+        42,
+        'Second paragraph.',
+      ])
+    ).to.eq('First paragraph. Second paragraph.')
+  })
+
+  it('returns empty string for unexpected scalar types', () => {
+    expect(normalizeTextField(42)).to.eq('')
+    expect(normalizeTextField(true)).to.eq('')
+  })
+})

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -279,10 +279,20 @@ export function cursorToPage(cursor: string) {
   return potentialPage <= 1 ? 1 : potentialPage
 }
 
+export function asHtmlString(value: unknown): string {
+  if (typeof value === 'string') return value
+  if (value == null) return ''
+  if (Array.isArray(value)) {
+    return value.filter((part): part is string => typeof part === 'string').join(' ')
+  }
+  return ''
+}
+
 export function truncate(
   str: string,
   { length = 30, separator = '…' }: { length?: number; separator?: string } = {}
 ): string {
+  str = asHtmlString(str)
   if (!str || str.length <= length) return str
   const slice = str.slice(0, length)
   const lastSpace = slice.lastIndexOf(' ')

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -208,6 +208,10 @@ export function mapJsonToWork(json: any, included: any[]) {
     id: DOI_ID_BASE + json.id,
     language: { id: attrs.language, name: ISO6391.getName(attrs.language) },
     rights: attrs.rightsList,
+    titles: (attrs.titles ?? []).map((t: { title?: unknown; titleType?: string; lang?: string }) => ({
+      ...t,
+      title: normalizeTextField(t.title),
+    })),
     descriptions: (attrs.descriptions ?? []).map((d: { description?: unknown; descriptionType?: string }) => ({
       ...d,
       description: normalizeTextField(d.description),
@@ -283,27 +287,22 @@ export function cursorToPage(cursor: string) {
   return potentialPage <= 1 ? 1 : potentialPage
 }
 
-export function asHtmlString(value: unknown): string {
-  if (typeof value === 'string') return value
-  if (value == null) return ''
-  if (Array.isArray(value)) {
-    return value.filter((part): part is string => typeof part === 'string').join(' ')
-  }
-  return ''
 export function normalizeTextField(value: unknown): string {
   if (value == null) return ''
   if (typeof value === 'string') return value
   if (Array.isArray(value)) {
-    return value.filter((item): item is string => typeof item === 'string' && item !== '').join(' ')
+    return value
+      .filter((item): item is string => typeof item === 'string' && item !== '')
+      .join(' ')
   }
-  return String(value)
+  return ''
 }
 
 export function truncate(
   str: string,
   { length = 30, separator = '…' }: { length?: number; separator?: string } = {}
 ): string {
-  str = asHtmlString(str)
+  str = normalizeTextField(str)
   if (!str || str.length <= length) return str
   const slice = str.slice(0, length)
   const lastSpace = slice.lastIndexOf(' ')


### PR DESCRIPTION
## Purpose
This PR addresses runtime issues when title or description metadata is not a plain string, and improves page performance by lazy-loading heavier chart/visualization components.

## Approach
- Introduced a small `asHtmlString` helper to normalize metadata values before they are sanitized, truncated, or parsed as HTML.
- Guarded `WorkMetadata` and `MetadataTable` rendering so empty/invalid titles fall back to "No Title" and empty descriptions render nothing.
- Wrapped chart components (`ForceDirectedGraph`, `UsageChart`, `WorksDashboard`, `SankeyGraph`) with `next/dynamic` so they are only loaded on the client.
- Extracted `multilevelToSankey` into its own utility module so it can be imported independently of the `SankeyGraph` component.

### Key Modifications
- **New `LazyForceDirectedGraph` component** (`src/components/ForceDirectedGraph/LazyForceDirectedGraph.tsx`) that dynamically imports `ForceDirectedGraph` with `ssr: false` and a loading fallback.
- **Updated `RelatedAggregateGraph.tsx`** to use `LazyForceDirectedGraph` instead of `ForceDirectedGraph`.
- **Updated `AnalyticsBar.tsx`** to dynamically import `UsageChart` with a loading placeholder.
- **Updated `WorksListing.tsx`** to dynamically import `WorksDashboard` and `SankeyGraph`; imported `ShowCharts` as a type and `multilevelToSankey` from the new `sankeyUtils.ts`.
- **New `src/components/SankeyGraph/sankeyUtils.ts`** containing the extracted `multilevelToSankey` function.
- **Updated `MetadataTable.tsx` and `WorkMetadata.tsx`** to use `asHtmlString` for titles and descriptions, with empty-value guards.
- **Updated `src/utils/helpers.ts`** to add `asHtmlString` and to make `truncate` coerce its input through `asHtmlString`.

### Important Technical Details
- `next/dynamic` with `ssr: false` keeps Vega/D3-based charts out of the server bundle, avoiding SSR rendering issues and reducing initial JavaScript payload.
- `asHtmlString` safely handles `string`, `null`/`undefined`, and arrays of strings (joining them with a space), preventing `sanitize-html` and `truncate` from receiving unexpected types.
- Moving `multilevelToSankey` into a separate utility avoids importing the entire `SankeyGraph` component just to transform facet data.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Loading connections…” loading state for the connections network while the graph renders.
  * Work-related charts now load client-side with loading fallbacks (including the usage chart and dashboard/charts views).

* **Improvements**
  * Improved HTML normalization for work titles and descriptions to make rendering and search summaries more consistent.

* **Refactor**
  * Moved Sankey data conversion into a dedicated utility module and updated components to use it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->