### PR TITLE
Migrate Cypress env access to cy.env and Cypress.expose to prevent sensitive value logging

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,13 +1,14 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
+  allowCypressEnv: false,
   video: false,
   projectId: 'yur1cf',
   retries: 2,
-  env: {
+  expose: {
     // Enabled for `cy:run` / CI (`CYPRESS_NODE_ENV=test`). Unmocked browser API calls fail with
-    // HTTP 599. Strict mode stays on unless you pass strictApiMocks: false (here, --env, or
-    // CYPRESS_strictApiMocks=false).
+    // HTTP 599. Strict mode stays on unless you pass strictApiMocks: false (here, --expose, or
+    // CYPRESS_expose_strictApiMocks=false).
     strictApiMocks: process.env.CYPRESS_NODE_ENV === 'test',
   },
   e2e: {

--- a/cypress/e2e/claim.test.ts
+++ b/cypress/e2e/claim.test.ts
@@ -1,7 +1,9 @@
 describe('Claim', () => {
   beforeEach(() => {
     cy.setCookie('_consent', 'true')
-    cy.setCookie('_datacite', Cypress.env('userCookie'), { log: false })
+    cy.env(['userCookie']).then(({ userCookie }) => {
+      cy.setCookie('_datacite', userCookie, { log: false })
+    })
   })
 
   // it('menu item', () => {

--- a/cypress/e2e/userMenu.test.ts
+++ b/cypress/e2e/userMenu.test.ts
@@ -3,7 +3,9 @@
 // describe('User Menu', () => {
 //   beforeEach(() => {
 //     cy.setCookie('_consent', 'true')
-//     cy.setCookie('_datacite', Cypress.env('userCookie'), { log: false })
+//     cy.env(['userCookie']).then(({ userCookie }) => {
+//       cy.setCookie('_datacite', userCookie, { log: false })
+//     })
 //   })
 
 // it('menu item', () => {

--- a/cypress/support/registerApiMocks.js
+++ b/cypress/support/registerApiMocks.js
@@ -2,8 +2,8 @@ const { matchRequest, isApiRequestUrl } = require('../mockApiRouter.cjs')
 
 // Strict API mocking is on unless explicitly disabled. Unmocked API requests get HTTP 599
 // instead of hitting the network. To turn strict mode off, set strictApiMocks: false in
-// cypress.config.ts env, pass --env strictApiMocks=false, or set CYPRESS_strictApiMocks=false.
-const strictMocks = Cypress.env('strictApiMocks') !== false
+// cypress.config.ts expose, pass --expose strictApiMocks=false, or set CYPRESS_expose_strictApiMocks=false.
+const strictMocks = Cypress.expose('strictApiMocks') !== false
 
 const API_INTERCEPT_PATTERNS = [
   '**/dois?*',


### PR DESCRIPTION
## Purpose

Update Cypress test setup and API mocking configuration to use the new environment access helpers (`cy.env` and `Cypress.expose`) instead of `Cypress.env`. This prevents sensitive values from being exposed in Cypress logs and aligns the test suite with the updated configuration pattern.

## Approach

### Key Modifications

- **`cypress/e2e/claim.test.ts`**: Replaced direct `Cypress.env('userCookie')` access with the async `cy.env(['userCookie'])` command and wrapped `cy.setCookie` inside the resulting `.then()` callback.
- **`cypress/e2e/userMenu.test.ts`**: Applied the same `cy.env` change to the commented-out test setup for consistency.
- **`cypress/support/registerApiMocks.js`**: Switched the `strictApiMocks` flag from `Cypress.env` to `Cypress.expose`, and updated the surrounding comments to reference the new exposure mechanism.

### Important Technical Details

- `cy.env()` is asynchronous and returns a thenable, so cookie setup must occur inside its callback.
- `Cypress.expose()` provides synchronous access to non-sensitive configuration values in support files.
- This change reduces the risk of leaking sensitive environment variables (e.g., user cookies) through Cypress command logs or UI snapshots.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved Cypress cookie handling by fetching `userCookie` through Cypress runtime variables before setting the `_datacite` cookie.
  * Updated Cypress configuration to use the `expose` mechanism (`allowCypressEnv: false`) while keeping existing run/CI behavior consistent.
  * Adjusted strict API mocking mode to read from the exposed configuration rather than direct environment access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->