### PR TITLE
Add doi sort option

### DIFF
--- a/src/app/(main)/doi.org/[...doi]/RelatedContent.tsx
+++ b/src/app/(main)/doi.org/[...doi]/RelatedContent.tsx
@@ -8,7 +8,7 @@ import Row from 'react-bootstrap/Row'
 
 import CommonsError from 'src/components/Error/Error'
 import Loading from 'src/components/Loading/Loading'
-import WorksListing from 'src/components/WorksListing/WorksListing'
+import WorksListing, { SortBy } from 'src/components/WorksListing/WorksListing'
 import SearchBox from 'src/components/SearchBox/SearchBox'
 import mapSearchparams from './mapSearchParams'
 import { useRelatedContentManager } from 'src/data/managers/RelatedContentManager'
@@ -60,7 +60,10 @@ export default function RelatedContent() {
         <Col md={3} className="d-none d-md-block">
         </Col>
         <Col md={9}>
-          <h3 className="member-results" id="title">Related Works</h3>
+          <Row className="border-bottom ms-1 mb-3">
+            <Col className="ps-0"><h3 className="member-results border-0 mb-0">Related Works</h3></Col>
+            <Col xs="auto"><SortBy /></Col>
+          </Row>
         </Col>
       </Row>
       <Row>

--- a/src/app/(main)/doi.org/[...doi]/RelatedContent.tsx
+++ b/src/app/(main)/doi.org/[...doi]/RelatedContent.tsx
@@ -61,7 +61,7 @@ export default function RelatedContent() {
         </Col>
         <Col md={9}>
           <Row className="border-bottom ms-1 mb-3">
-            <Col className="ps-0"><h3 className="member-results border-0 mb-0">Related Works</h3></Col>
+            <Col className="ps-0"><h3 className="member-results border-0 mb-0" id="title">Related Works</h3></Col>
             <Col xs="auto"><SortBy /></Col>
           </Row>
         </Col>

--- a/src/app/(main)/orcid.org/[orcid]/RelatedContent.tsx
+++ b/src/app/(main)/orcid.org/[orcid]/RelatedContent.tsx
@@ -9,7 +9,7 @@ import Loading from 'src/components/Loading/Loading'
 import { usePersonRelatedContentQuery } from 'src/data/queries/personRelatedContentQuery'
 
 import Error from 'src/components/Error/Error'
-import WorksListing from 'src/components/WorksListing/WorksListing'
+import WorksListing, { SortBy } from 'src/components/WorksListing/WorksListing'
 import SearchBox from 'src/components/SearchBox/SearchBox'
 import { pluralize } from 'src/utils/helpers';
 import { useParams, useSearchParams } from 'next/navigation'
@@ -58,7 +58,10 @@ export default function RelatedContent(props: Props) {
       <Col md={3} className="d-none d-md-block">
       </Col>
       <Col md={9}>
-        <h3 className="member-results" id="title">{pluralize(relatedWorks.totalCount, 'Work')}</h3>
+        <Row className="border-bottom ms-1 mb-3">
+          <Col className="ps-0"><h3 className="member-results border-0 mb-0">{pluralize(relatedWorks.totalCount, 'Work')}</h3></Col>
+          <Col xs="auto"><SortBy /></Col>
+        </Row>
       </Col>
     </Row>
     <WorksListing

--- a/src/app/(main)/orcid.org/[orcid]/mapSearchParams.ts
+++ b/src/app/(main)/orcid.org/[orcid]/mapSearchParams.ts
@@ -1,3 +1,5 @@
+import { SortOption } from "src/data/queries/searchDoiQuery"
+
 export interface SearchParams {
   filterQuery?: string
   cursor?: string
@@ -10,6 +12,7 @@ export interface SearchParams {
   "registration-agency"?: string
   "organization-relation-type"?: string
   "client-id"?: string
+  sort?: SortOption
   isBot: string
 }
 
@@ -27,6 +30,7 @@ export default function mapSearchparams(searchParams: SearchParams) {
       registrationAgency: searchParams['registration-agency'],
       organizationRelationType: searchParams['organization-relation-type'] || 'allRelated',
       clientId: searchParams['client-id'],
+      sort: searchParams.sort
     },
 
     isBot: false

--- a/src/app/(main)/orcid.org/[orcid]/mapSearchParams.ts
+++ b/src/app/(main)/orcid.org/[orcid]/mapSearchParams.ts
@@ -1,4 +1,4 @@
-import { SortOption } from "src/data/queries/searchDoiQuery"
+import type { SortOption } from 'src/data/queries/searchDoiQuery'
 
 export interface SearchParams {
   filterQuery?: string

--- a/src/app/(main)/repositories/[...repoid]/RelatedContent.tsx
+++ b/src/app/(main)/repositories/[...repoid]/RelatedContent.tsx
@@ -9,7 +9,7 @@ import Loading from 'src/components/Loading/Loading'
 import { useRepositoryRelatedContentQuery } from 'src/data/queries/repositoryRelatedContentQuery'
 
 import Error from 'src/components/Error/Error'
-import WorksListing from 'src/components/WorksListing/WorksListing'
+import WorksListing, { SortBy } from 'src/components/WorksListing/WorksListing'
 import { pluralize } from 'src/utils/helpers';
 import { useSearchParams } from 'next/navigation';
 import mapSearchparams from './mapSearchParams';
@@ -56,8 +56,13 @@ export default function RelatedContent({ repository }: Props) {
         <Col md={3} className="d-none d-md-block">
         </Col>
         <Col md={9}>
-          <h2 className="visually-hidden">Related Works Results Summary</h2>
-          <h3 className="member-results">{pluralize(totalCount, 'Work')}</h3>
+          <Row className="border-bottom ms-1 mb-3">
+            <Col className="ps-0">
+              <h2 className="visually-hidden">Related Works Results Summary</h2>
+              <h3 className="member-results border-0 mb-0">{pluralize(totalCount, 'Work')}</h3>
+            </Col>
+            <Col xs="auto"><SortBy /></Col>
+          </Row>
         </Col>
       </Row>
       <WorksListing

--- a/src/app/(main)/repositories/[...repoid]/mapSearchParams.ts
+++ b/src/app/(main)/repositories/[...repoid]/mapSearchParams.ts
@@ -1,4 +1,4 @@
-import { SortOption } from "src/data/queries/searchDoiQuery"
+import type { SortOption } from 'src/data/queries/searchDoiQuery'
 
 export interface SearchParams {
   id: string

--- a/src/app/(main)/repositories/[...repoid]/mapSearchParams.ts
+++ b/src/app/(main)/repositories/[...repoid]/mapSearchParams.ts
@@ -1,3 +1,5 @@
+import { SortOption } from "src/data/queries/searchDoiQuery"
+
 export interface SearchParams {
   id: string
   filterQuery?: string
@@ -9,6 +11,7 @@ export interface SearchParams {
   license?: string
   "field-of-science"?: string
   "registration-agency"?: string
+  sort?: SortOption
 
   isBot: string
 }
@@ -25,7 +28,8 @@ export default function mapSearchparams(searchParams: SearchParams) {
       fieldOfScience: searchParams['field-of-science'],
       license: searchParams.license,
       registrationAgency: searchParams['registration-agency'],
-      clientType: searchParams['repository-type']
+      clientType: searchParams['repository-type'],
+      sort: searchParams.sort
     },
 
     isBot: false

--- a/src/app/(main)/ror.org/[rorid]/RelatedContent.tsx
+++ b/src/app/(main)/ror.org/[rorid]/RelatedContent.tsx
@@ -6,7 +6,7 @@ import Col from 'react-bootstrap/Col'
 import Row from 'react-bootstrap/Row'
 import Loading from 'src/components/Loading/Loading'
 import CommonsError from 'src/components/Error/Error'
-import WorksListing from 'src/components/WorksListing/WorksListing'
+import WorksListing, { SortBy } from 'src/components/WorksListing/WorksListing'
 import { useParams, useSearchParams } from 'next/navigation'
 import mapSearchparams from './mapSearchParams'
 import { useOrganizationRelatedContentManager } from 'src/data/managers/OrganizationRelatedContentManager'
@@ -56,7 +56,10 @@ export default function RelatedContent() {
     <Container fluid className="mt-5">
       <Row>
         <Col md={{ offset: 3 }} className="px-0">
-          <h3 className="member-results" id="title">Related Works</h3>
+          <Row className="border-bottom ms-1 mb-3">
+            <Col className="ps-0"><h3 className="member-results border-0 mb-0">Related Works</h3></Col>
+            <Col xs="auto"><SortBy /></Col>
+          </Row>
         </Col>
       </Row>
       <Row>
@@ -70,7 +73,7 @@ export default function RelatedContent() {
           hasPagination={hasPagination}
           hasNextPage={hasNextPage}
           model={'organization'}
-          url={url+ '?'}
+          url={url + '?'}
           endCursor={endCursor}
           searchBox={<SearchBox path={url} placeholder="Search within these works..." />}
         >

--- a/src/components/SearchWork/SearchWork.tsx
+++ b/src/components/SearchWork/SearchWork.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React from 'react'
+import React, { Suspense } from 'react'
 import Loading from '../Loading/Loading'
 import Row from 'react-bootstrap/Row'
 import Col from 'react-bootstrap/Col'
@@ -42,7 +42,7 @@ export default function SearchWork(props: Props) {
         {works.totalCount > 0 && (
           <Row className="border-bottom ms-1 mb-3">
             <Col className="ps-0"><h3 className="member-results border-0 mb-0">{pluralize(works.totalCount, 'Work')}</h3></Col>
-            <Col xs="auto"><SortBy /></Col>
+            <Col xs="auto"><Suspense><SortBy /></Suspense></Col>
           </Row>
         )}
       </Col>

--- a/src/components/SearchWork/SearchWork.tsx
+++ b/src/components/SearchWork/SearchWork.tsx
@@ -10,7 +10,7 @@ import { QueryVar, useSearchDoiQuery } from 'src/data/queries/searchDoiQuery'
 import { useSearchDoiFacetsQuery } from 'src/data/queries/searchDoiFacetsQuery'
 
 import NoResults from 'src/components/NoResults/NoResults'
-import WorksListing from 'src/components/WorksListing/WorksListing'
+import WorksListing, { SortBy } from 'src/components/WorksListing/WorksListing'
 import { pluralize } from 'src/utils/helpers'
 
 interface Props {
@@ -40,7 +40,10 @@ export default function SearchWork(props: Props) {
       </Col>
       <Col md={9}>
         {works.totalCount > 0 && (
-          <h3 className="member-results">{pluralize(works.totalCount, 'Work')}</h3>
+          <Row className="border-bottom ms-1 mb-3">
+            <Col className="ps-0"><h3 className="member-results border-0 mb-0">{pluralize(works.totalCount, 'Work')}</h3></Col>
+            <Col xs="auto"><SortBy /></Col>
+          </Row>
         )}
       </Col>
     </Row>

--- a/src/components/WorksListing/WorksListing.tsx
+++ b/src/components/WorksListing/WorksListing.tsx
@@ -15,6 +15,11 @@ import NoResults from 'src/components/NoResults/NoResults'
 import Pager from 'src/components/Pager/Pager'
 import type { ShowCharts } from 'src/components/WorksDashboard/WorksDashboard'
 import { multilevelToSankey } from 'src/components/SankeyGraph/sankeyUtils'
+import Dropdown from 'react-bootstrap/Dropdown'
+import { faSortAlphaAsc, faSortAlphaDesc, faSortAmountAsc, faSortNumericAsc, faSortNumericDesc, IconDefinition } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { usePathname, useSearchParams } from 'next/navigation'
+import { VALID_SORT_OPTIONS } from 'src/data/queries/searchDoiQuery'
 
 const WorksDashboard = dynamic(() => import('src/components/WorksDashboard/WorksDashboard'), { ssr: false })
 const SankeyGraph = dynamic(() => import('src/components/SankeyGraph/SankeyGraph'), { ssr: false })
@@ -135,4 +140,88 @@ export default function WorksListing({
       </Col>
     </Row>
   )
+}
+
+
+
+const A_TO_Z = 'A to Z'
+const Z_TO_A = 'Z to A'
+const NEWEST_FIRST = 'newest first'
+const OLDEST_FIRST = 'oldest first'
+const HIGH_TO_LOW = 'high to low'
+const LOW_TO_HIGH = 'low to high'
+
+const SORT_OPTIONS = [
+  { value: 'relevance', label: 'Relevance (default)', order: undefined, icon: faSortAmountAsc },
+  { value: '-published', label: 'Published', order: NEWEST_FIRST, icon: faSortNumericDesc },
+  { value: 'published', label: 'Published', order: OLDEST_FIRST, icon: faSortNumericAsc },
+  // { value: 'name', label: 'DOI Name', order: A_TO_Z, icon: faSortAlphaAsc },
+  // { value: '-name', label: 'DOI Name', order: Z_TO_A, icon: faSortAlphaDesc },
+  { value: 'title', label: 'Title', order: A_TO_Z, icon: faSortAlphaAsc },
+  { value: '-title', label: 'Title', order: Z_TO_A, icon: faSortAlphaDesc },
+  // { value: '-created', label: 'Created', order: NEWEST_FIRST, icon: faSortNumericDesc },
+  // { value: 'created', label: 'Created', order: OLDEST_FIRST, icon: faSortNumericAsc },
+  // { value: '-updated', label: 'Updated', order: NEWEST_FIRST, icon: faSortNumericDesc },
+  // { value: 'updated', label: 'Updated', order: OLDEST_FIRST, icon: faSortNumericAsc },
+  { value: '-citation-count', label: 'Most Cited', order: undefined, icon: faSortNumericDesc },
+  // { value: 'citation-count', label: 'Citation Count', order: LOW_TO_HIGH, icon: faSortNumericAsc },
+  { value: '-view-count', label: 'Most Viewed', order: undefined, icon: faSortNumericDesc },
+  // { value: 'view-count', label: 'View Count', order: LOW_TO_HIGH, icon: faSortNumericAsc },
+  { value: '-download-count', label: 'Most Downloaded', order: undefined, icon: faSortNumericDesc },
+  // { value: 'download-count', label: 'Download Count', order: LOW_TO_HIGH, icon: faSortNumericAsc },
+] as const
+
+export function SortBy() {
+  const searchParams = useSearchParams()
+  const params = new URLSearchParams(Array.from(searchParams?.entries() || []));
+
+  const activeSort = SORT_OPTIONS.find(e => e.value === params.get('sort')) || { label: 'Sort by...', icon: faSortAmountAsc }
+
+  return <Dropdown>
+    <Dropdown.Toggle className="border-0 m-0" variant="light">
+      <FontAwesomeIcon icon={activeSort.icon} /> {activeSort.label}
+    </Dropdown.Toggle>
+
+    <Dropdown.Menu>
+      {SORT_OPTIONS.map((item) => (
+        <Item
+          key={item.value}
+          value={item.value}
+          order={item.order}
+          icon={item.icon}
+        >
+          {item.label}
+        </Item>
+      ))}
+    </Dropdown.Menu>
+  </Dropdown>
+}
+
+function Item(props: {
+  value: typeof VALID_SORT_OPTIONS[number],
+  order?: string,
+  icon: IconDefinition,
+  children: React.ReactNode
+}) {
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const params = new URLSearchParams(Array.from(searchParams?.entries() || []));
+
+  console.log(pathname)
+
+  const isActive = params.get('sort') == props.value
+
+  if (isActive) {
+    // if param is present, delete from query
+    params.delete('sort')
+  } else {
+    // otherwise replace param with new value
+    params.set('sort', props.value)
+  }
+  params.delete('cursor')
+
+  return <Dropdown.Item href={`${pathname}/?${params.toString()}`} active={isActive} className="d-inline-flex align-items-center gap-1">
+    <FontAwesomeIcon className={!isActive ? "text-secondary" : ""} icon={props.icon} /> {props.children}
+    {props.order && <span className={`${!isActive ? "text-secondary" : ""} ms-auto text-end ps-4`}>{props.order}</span>}
+  </Dropdown.Item>
 }

--- a/src/components/WorksListing/WorksListing.tsx
+++ b/src/components/WorksListing/WorksListing.tsx
@@ -153,13 +153,13 @@ const HIGH_TO_LOW = 'high to low'
 const LOW_TO_HIGH = 'low to high'
 
 const SORT_OPTIONS = [
-  // { value: 'relevance', label: 'Relevance (default)', order: undefined, icon: faSortAmountAsc },
+  { value: 'relevance', label: 'Relevance (default)', order: undefined, icon: faSortAmountAsc, appendDivider: true },
   // { value: '-published', label: 'Published', order: NEWEST_FIRST, icon: faSortNumericDesc },
   // { value: 'published', label: 'Published', order: OLDEST_FIRST, icon: faSortNumericAsc },
   // { value: 'name', label: 'DOI Name', order: A_TO_Z, icon: faSortAlphaAsc },
   // { value: '-name', label: 'DOI Name', order: Z_TO_A, icon: faSortAlphaDesc },
   { value: 'title', label: 'Title', order: A_TO_Z, icon: faSortAlphaAsc },
-  { value: '-title', label: 'Title', order: Z_TO_A, icon: faSortAlphaDesc },
+  { value: '-title', label: 'Title', order: Z_TO_A, icon: faSortAlphaDesc, appendDivider: true },
   // { value: '-created', label: 'Created', order: NEWEST_FIRST, icon: faSortNumericDesc },
   // { value: 'created', label: 'Created', order: OLDEST_FIRST, icon: faSortNumericAsc },
   // { value: '-updated', label: 'Updated', order: NEWEST_FIRST, icon: faSortNumericDesc },
@@ -188,7 +188,7 @@ export function SortBy() {
       href={`${pathname}/?${params.toString()}`}
       id="search-clear"
       type="button"
-      title="Clear sort"
+      title="Revert to default sort (Relevance)"
       aria-label="Clear sort"
       className="text-secondary"
     >
@@ -200,16 +200,19 @@ export function SortBy() {
         <FontAwesomeIcon icon={activeSort.icon} /> {activeSort.label}
       </Dropdown.Toggle>
 
-      <Dropdown.Menu>
+      <Dropdown.Menu className="remove-dropdown-margin">
         {SORT_OPTIONS.map((item) => (
-          <Item
-            key={item.value}
-            value={item.value}
-            order={item.order}
-            icon={item.icon}
-          >
-            {item.label}
-          </Item>
+          <>
+            <Item
+              key={item.value}
+              value={item.value}
+              order={item.order}
+              icon={item.icon}
+            >
+              {item.label}
+            </Item>
+            {item.appendDivider && <Dropdown.Divider className="pt-1 border-0" />}
+          </>
         ))}
       </Dropdown.Menu>
     </Dropdown>
@@ -226,7 +229,7 @@ function Item(props: {
   const searchParams = useSearchParams()
   const params = new URLSearchParams(Array.from(searchParams?.entries() || []));
 
-  const isActive = params.get('sort') == props.value
+  const isActive = params.get('sort') === props.value || (props.value === 'relevance' && !params.get('sort'))
 
   if (isActive) {
     // if param is present, delete from query

--- a/src/components/WorksListing/WorksListing.tsx
+++ b/src/components/WorksListing/WorksListing.tsx
@@ -207,8 +207,6 @@ function Item(props: {
   const searchParams = useSearchParams()
   const params = new URLSearchParams(Array.from(searchParams?.entries() || []));
 
-  console.log(pathname)
-
   const isActive = params.get('sort') == props.value
 
   if (isActive) {

--- a/src/components/WorksListing/WorksListing.tsx
+++ b/src/components/WorksListing/WorksListing.tsx
@@ -211,7 +211,7 @@ export function SortBy() {
             >
               {item.label}
             </Item>
-            {item.appendDivider && <Dropdown.Divider className="pt-1 border-0" />}
+            {'appendDivider' in item && item.appendDivider && <Dropdown.Divider className="pt-1 border-0" />}
           </>
         ))}
       </Dropdown.Menu>

--- a/src/components/WorksListing/WorksListing.tsx
+++ b/src/components/WorksListing/WorksListing.tsx
@@ -229,7 +229,8 @@ function Item(props: {
   const searchParams = useSearchParams()
   const params = new URLSearchParams(Array.from(searchParams?.entries() || []));
 
-  const isActive = params.get('sort') === props.value || (props.value === 'relevance' && !params.get('sort'))
+  const isActive = params.get('sort') === props.value
+  const isSelected = isActive || (props.value === 'relevance' && !params.get('sort'))
 
   if (isActive) {
     // if param is present, delete from query
@@ -240,7 +241,7 @@ function Item(props: {
   }
   params.delete('cursor')
 
-  return <Dropdown.Item href={`${pathname}/?${params.toString()}`} active={isActive} className="d-inline-flex align-items-center gap-1" as={Link}>
+  return <Dropdown.Item href={`${pathname}/?${params.toString()}`} active={isSelected} className="d-inline-flex align-items-center gap-1" as={Link}>
     <FontAwesomeIcon className={!isActive ? "text-secondary" : ""} icon={props.icon} /> {props.children}
     {props.order && <span className={`${!isActive ? "text-secondary" : ""} ms-auto text-end ps-4`}>{props.order}</span>}
   </Dropdown.Item>

--- a/src/components/WorksListing/WorksListing.tsx
+++ b/src/components/WorksListing/WorksListing.tsx
@@ -16,10 +16,10 @@ import Pager from 'src/components/Pager/Pager'
 import type { ShowCharts } from 'src/components/WorksDashboard/WorksDashboard'
 import { multilevelToSankey } from 'src/components/SankeyGraph/sankeyUtils'
 import Dropdown from 'react-bootstrap/Dropdown'
-import { faCheck, faSortAmountAsc } from '@fortawesome/free-solid-svg-icons'
+import { faCheck } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { usePathname, useSearchParams } from 'next/navigation'
-import { VALID_SORT_OPTIONS } from 'src/data/queries/searchDoiQuery'
+import type { SortOption } from 'src/data/queries/searchDoiQuery'
 import Link from 'next/link'
 
 const WorksDashboard = dynamic(() => import('src/components/WorksDashboard/WorksDashboard'), { ssr: false })
@@ -156,11 +156,7 @@ export function SortBy() {
   const searchParams = useSearchParams()
   const params = new URLSearchParams(Array.from(searchParams?.entries() || []));
 
-  const activeSort = SORT_OPTIONS.find(e => e.value === params.get('sort')) || { value: undefined, label: 'Sort by...', icon: faSortAmountAsc }
-
-  // Reset sort params for 'Clear' button
-  params.delete('sort')
-  params.delete('cursor')
+  const activeSort = SORT_OPTIONS.find(e => e.value === params.get('sort')) || SORT_OPTIONS[0]
 
   return <div className="d-flex align-items-center">
     <Dropdown>
@@ -183,7 +179,7 @@ export function SortBy() {
 }
 
 function Item(props: {
-  value: null | typeof VALID_SORT_OPTIONS[number],
+  value: null | SortOption,
   children: React.ReactNode
 }) {
   const pathname = usePathname()
@@ -191,7 +187,7 @@ function Item(props: {
   const params = new URLSearchParams(Array.from(searchParams?.entries() || []));
 
   const isActive = params.get('sort') === props.value
-  const isSelected = isActive || (props.value === 'relevance' && !params.get('sort'))
+  const isSelected = isActive
 
   if (isActive || !props.value) {
     // if param is present, delete from query

--- a/src/components/WorksListing/WorksListing.tsx
+++ b/src/components/WorksListing/WorksListing.tsx
@@ -16,7 +16,7 @@ import Pager from 'src/components/Pager/Pager'
 import type { ShowCharts } from 'src/components/WorksDashboard/WorksDashboard'
 import { multilevelToSankey } from 'src/components/SankeyGraph/sankeyUtils'
 import Dropdown from 'react-bootstrap/Dropdown'
-import { faCheck, faSortAlphaAsc, faSortAlphaUp, faSortAmountAsc, faSortNumericUp, IconDefinition } from '@fortawesome/free-solid-svg-icons'
+import { faCheck, faSortAmountAsc } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { usePathname, useSearchParams } from 'next/navigation'
 import { VALID_SORT_OPTIONS } from 'src/data/queries/searchDoiQuery'
@@ -143,33 +143,13 @@ export default function WorksListing({
   )
 }
 
-
-
-const A_TO_Z = 'A to Z'
-const Z_TO_A = 'Z to A'
-// const NEWEST_FIRST = 'newest first'
-// const OLDEST_FIRST = 'oldest first'
-// const HIGH_TO_LOW = 'high to low'
-// const LOW_TO_HIGH = 'low to high'
-
 const SORT_OPTIONS = [
-  { value: null, label: 'Relevance', order: undefined, icon: faSortAmountAsc, appendDivider: true },
-  // { value: '-published', label: 'Published', order: NEWEST_FIRST, icon: faSortNumericDesc },
-  // { value: 'published', label: 'Published', order: OLDEST_FIRST, icon: faSortNumericAsc },
-  // { value: 'name', label: 'DOI Name', order: A_TO_Z, icon: faSortAlphaAsc },
-  // { value: '-name', label: 'DOI Name', order: Z_TO_A, icon: faSortAlphaDesc },
-  { value: 'title', label: 'Title', order: A_TO_Z, icon: faSortAlphaAsc },
-  { value: '-title', label: 'Title', order: Z_TO_A, icon: faSortAlphaUp, appendDivider: true },
-  // { value: '-created', label: 'Created', order: NEWEST_FIRST, icon: faSortNumericDesc },
-  // { value: 'created', label: 'Created', order: OLDEST_FIRST, icon: faSortNumericAsc },
-  // { value: '-updated', label: 'Updated', order: NEWEST_FIRST, icon: faSortNumericDesc },
-  // { value: 'updated', label: 'Updated', order: OLDEST_FIRST, icon: faSortNumericAsc },
-  { value: '-citation-count', label: 'Most Cited', order: undefined, icon: faSortNumericUp },
-  // { value: 'citation-count', label: 'Citation Count', order: LOW_TO_HIGH, icon: faSortNumericAsc },
-  { value: '-view-count', label: 'Most Viewed', order: undefined, icon: faSortNumericUp },
-  // { value: 'view-count', label: 'View Count', order: LOW_TO_HIGH, icon: faSortNumericAsc },
-  { value: '-download-count', label: 'Most Downloaded', order: undefined, icon: faSortNumericUp },
-  // { value: 'download-count', label: 'Download Count', order: LOW_TO_HIGH, icon: faSortNumericAsc },
+  { value: null, label: 'Relevance', appendDivider: true },
+  { value: 'title', label: 'Title (A to Z)' },
+  { value: '-title', label: 'Title (Z to A)', appendDivider: true },
+  { value: '-citation-count', label: 'Most Cited' },
+  { value: '-view-count', label: 'Most Viewed' },
+  { value: '-download-count', label: 'Most Downloaded' },
 ] as const
 
 export function SortBy() {
@@ -185,22 +165,17 @@ export function SortBy() {
   return <div className="d-flex align-items-center">
     <Dropdown>
       <Dropdown.Toggle className="border-0 m-0 bg-transparent" variant="light">
-        <span className="text-secondary">Sort by:</span> {activeSort.label} {"order" in activeSort && activeSort.order && `(${activeSort.order})`}
+        <span className="text-secondary">Sort by:</span> {activeSort.label}
       </Dropdown.Toggle>
 
       <Dropdown.Menu className="remove-dropdown-margin">
         {SORT_OPTIONS.map((item) => (
-          <>
-            <Item
-              key={item.value}
-              value={item.value}
-              order={item.order}
-              icon={item.icon}
-            >
+          <React.Fragment key={item.value}>
+            <Item value={item.value}>
               {item.label}
             </Item>
             {'appendDivider' in item && item.appendDivider && <Dropdown.Divider className="pt-1 border-0" />}
-          </>
+          </React.Fragment>
         ))}
       </Dropdown.Menu>
     </Dropdown>
@@ -209,8 +184,6 @@ export function SortBy() {
 
 function Item(props: {
   value: null | typeof VALID_SORT_OPTIONS[number],
-  order?: string,
-  icon: IconDefinition,
   children: React.ReactNode
 }) {
   const pathname = usePathname()
@@ -232,6 +205,5 @@ function Item(props: {
   return <Dropdown.Item href={`${pathname}/?${params.toString()}`} className="d-inline-flex align-items-center gap-1" as={Link}>
     <FontAwesomeIcon icon={faCheck} opacity={isSelected ? 1 : 0} />
     {props.children}
-    {props.order && <span className="text-secondary ms-auto text-end ps-4">{props.order}</span>}
   </Dropdown.Item>
 }

--- a/src/components/WorksListing/WorksListing.tsx
+++ b/src/components/WorksListing/WorksListing.tsx
@@ -242,7 +242,7 @@ function Item(props: {
   params.delete('cursor')
 
   return <Dropdown.Item href={`${pathname}/?${params.toString()}`} active={isSelected} className="d-inline-flex align-items-center gap-1" as={Link}>
-    <FontAwesomeIcon className={!isActive ? "text-secondary" : ""} icon={props.icon} /> {props.children}
-    {props.order && <span className={`${!isActive ? "text-secondary" : ""} ms-auto text-end ps-4`}>{props.order}</span>}
+    <FontAwesomeIcon className={!isSelected ? "text-secondary" : ""} icon={props.icon} /> {props.children}
+    {props.order && <span className={`${!isSelected ? "text-secondary" : ""} ms-auto text-end ps-4`}>{props.order}</span>}
   </Dropdown.Item>
 }

--- a/src/components/WorksListing/WorksListing.tsx
+++ b/src/components/WorksListing/WorksListing.tsx
@@ -16,7 +16,7 @@ import Pager from 'src/components/Pager/Pager'
 import type { ShowCharts } from 'src/components/WorksDashboard/WorksDashboard'
 import { multilevelToSankey } from 'src/components/SankeyGraph/sankeyUtils'
 import Dropdown from 'react-bootstrap/Dropdown'
-import { faSortAlphaAsc, faSortAlphaDesc, faSortAmountAsc, faSortNumericAsc, faSortNumericDesc, IconDefinition } from '@fortawesome/free-solid-svg-icons'
+import { faSortAlphaAsc, faSortAlphaDesc, faSortAmountAsc, faSortNumericAsc, faSortNumericDesc, faTimes, IconDefinition } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { usePathname, useSearchParams } from 'next/navigation'
 import { VALID_SORT_OPTIONS } from 'src/data/queries/searchDoiQuery'
@@ -153,9 +153,9 @@ const HIGH_TO_LOW = 'high to low'
 const LOW_TO_HIGH = 'low to high'
 
 const SORT_OPTIONS = [
-  { value: 'relevance', label: 'Relevance (default)', order: undefined, icon: faSortAmountAsc },
-  { value: '-published', label: 'Published', order: NEWEST_FIRST, icon: faSortNumericDesc },
-  { value: 'published', label: 'Published', order: OLDEST_FIRST, icon: faSortNumericAsc },
+  // { value: 'relevance', label: 'Relevance (default)', order: undefined, icon: faSortAmountAsc },
+  // { value: '-published', label: 'Published', order: NEWEST_FIRST, icon: faSortNumericDesc },
+  // { value: 'published', label: 'Published', order: OLDEST_FIRST, icon: faSortNumericAsc },
   // { value: 'name', label: 'DOI Name', order: A_TO_Z, icon: faSortAlphaAsc },
   // { value: '-name', label: 'DOI Name', order: Z_TO_A, icon: faSortAlphaDesc },
   { value: 'title', label: 'Title', order: A_TO_Z, icon: faSortAlphaAsc },
@@ -173,29 +173,47 @@ const SORT_OPTIONS = [
 ] as const
 
 export function SortBy() {
+  const pathname = usePathname()
   const searchParams = useSearchParams()
   const params = new URLSearchParams(Array.from(searchParams?.entries() || []));
 
-  const activeSort = SORT_OPTIONS.find(e => e.value === params.get('sort')) || { label: 'Sort by...', icon: faSortAmountAsc }
+  const activeSort = SORT_OPTIONS.find(e => e.value === params.get('sort')) || { value: undefined, label: 'Sort by...', icon: faSortAmountAsc }
 
-  return <Dropdown>
-    <Dropdown.Toggle className="border-0 m-0" variant="light">
-      <FontAwesomeIcon icon={activeSort.icon} /> {activeSort.label}
-    </Dropdown.Toggle>
+  // Reset sort params for 'Clear' button
+  params.delete('sort')
+  params.delete('cursor')
 
-    <Dropdown.Menu>
-      {SORT_OPTIONS.map((item) => (
-        <Item
-          key={item.value}
-          value={item.value}
-          order={item.order}
-          icon={item.icon}
-        >
-          {item.label}
-        </Item>
-      ))}
-    </Dropdown.Menu>
-  </Dropdown>
+  return <div className="d-flex align-items-center">
+    {activeSort.value && <Link
+      href={`${pathname}/?${params.toString()}`}
+      id="search-clear"
+      type="button"
+      title="Clear sort"
+      aria-label="Clear sort"
+      className="text-secondary"
+    >
+      <FontAwesomeIcon icon={faTimes} />
+    </Link>
+    }
+    <Dropdown>
+      <Dropdown.Toggle className="border-0 m-0" variant="light">
+        <FontAwesomeIcon icon={activeSort.icon} /> {activeSort.label}
+      </Dropdown.Toggle>
+
+      <Dropdown.Menu>
+        {SORT_OPTIONS.map((item) => (
+          <Item
+            key={item.value}
+            value={item.value}
+            order={item.order}
+            icon={item.icon}
+          >
+            {item.label}
+          </Item>
+        ))}
+      </Dropdown.Menu>
+    </Dropdown>
+  </div>
 }
 
 function Item(props: {

--- a/src/components/WorksListing/WorksListing.tsx
+++ b/src/components/WorksListing/WorksListing.tsx
@@ -16,7 +16,7 @@ import Pager from 'src/components/Pager/Pager'
 import type { ShowCharts } from 'src/components/WorksDashboard/WorksDashboard'
 import { multilevelToSankey } from 'src/components/SankeyGraph/sankeyUtils'
 import Dropdown from 'react-bootstrap/Dropdown'
-import { faSortAlphaAsc, faSortAlphaDesc, faSortAmountAsc, faSortNumericAsc, faSortNumericDesc, faTimes, IconDefinition } from '@fortawesome/free-solid-svg-icons'
+import { faSortAlphaAsc, faSortAlphaDesc, faSortAlphaUp, faSortAmountAsc, faSortNumericAsc, faSortNumericDesc, faSortNumericUp, faTimes, IconDefinition } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { usePathname, useSearchParams } from 'next/navigation'
 import { VALID_SORT_OPTIONS } from 'src/data/queries/searchDoiQuery'
@@ -153,22 +153,22 @@ const HIGH_TO_LOW = 'high to low'
 const LOW_TO_HIGH = 'low to high'
 
 const SORT_OPTIONS = [
-  { value: 'relevance', label: 'Relevance (default)', order: undefined, icon: faSortAmountAsc, appendDivider: true },
+  // { value: 'relevance', label: 'Relevance (default)', order: undefined, icon: faSortAmountAsc, appendDivider: true },
   // { value: '-published', label: 'Published', order: NEWEST_FIRST, icon: faSortNumericDesc },
   // { value: 'published', label: 'Published', order: OLDEST_FIRST, icon: faSortNumericAsc },
   // { value: 'name', label: 'DOI Name', order: A_TO_Z, icon: faSortAlphaAsc },
   // { value: '-name', label: 'DOI Name', order: Z_TO_A, icon: faSortAlphaDesc },
   { value: 'title', label: 'Title', order: A_TO_Z, icon: faSortAlphaAsc },
-  { value: '-title', label: 'Title', order: Z_TO_A, icon: faSortAlphaDesc, appendDivider: true },
+  { value: '-title', label: 'Title', order: Z_TO_A, icon: faSortAlphaUp, appendDivider: true },
   // { value: '-created', label: 'Created', order: NEWEST_FIRST, icon: faSortNumericDesc },
   // { value: 'created', label: 'Created', order: OLDEST_FIRST, icon: faSortNumericAsc },
   // { value: '-updated', label: 'Updated', order: NEWEST_FIRST, icon: faSortNumericDesc },
   // { value: 'updated', label: 'Updated', order: OLDEST_FIRST, icon: faSortNumericAsc },
-  { value: '-citation-count', label: 'Most Cited', order: undefined, icon: faSortNumericDesc },
+  { value: '-citation-count', label: 'Most Cited', order: undefined, icon: faSortNumericUp },
   // { value: 'citation-count', label: 'Citation Count', order: LOW_TO_HIGH, icon: faSortNumericAsc },
-  { value: '-view-count', label: 'Most Viewed', order: undefined, icon: faSortNumericDesc },
+  { value: '-view-count', label: 'Most Viewed', order: undefined, icon: faSortNumericUp },
   // { value: 'view-count', label: 'View Count', order: LOW_TO_HIGH, icon: faSortNumericAsc },
-  { value: '-download-count', label: 'Most Downloaded', order: undefined, icon: faSortNumericDesc },
+  { value: '-download-count', label: 'Most Downloaded', order: undefined, icon: faSortNumericUp },
   // { value: 'download-count', label: 'Download Count', order: LOW_TO_HIGH, icon: faSortNumericAsc },
 ] as const
 
@@ -184,17 +184,6 @@ export function SortBy() {
   params.delete('cursor')
 
   return <div className="d-flex align-items-center">
-    {activeSort.value && <Link
-      href={`${pathname}/?${params.toString()}`}
-      id="search-clear"
-      type="button"
-      title="Revert to default sort (Relevance)"
-      aria-label="Clear sort"
-      className="text-secondary"
-    >
-      <FontAwesomeIcon icon={faTimes} />
-    </Link>
-    }
     <Dropdown>
       <Dropdown.Toggle className="border-0 m-0" variant="light">
         <FontAwesomeIcon icon={activeSort.icon} /> {activeSort.label}
@@ -216,6 +205,17 @@ export function SortBy() {
         ))}
       </Dropdown.Menu>
     </Dropdown>
+
+    {activeSort.value && <Link
+      href={`${pathname}/?${params.toString()}`}
+      id="search-clear"
+      type="button"
+      title="Clear sort"
+      aria-label="Clear sort"
+      className="text-secondary"
+    >
+      <FontAwesomeIcon icon={faTimes} />
+    </Link>}
   </div>
 }
 

--- a/src/components/WorksListing/WorksListing.tsx
+++ b/src/components/WorksListing/WorksListing.tsx
@@ -20,6 +20,7 @@ import { faSortAlphaAsc, faSortAlphaDesc, faSortAmountAsc, faSortNumericAsc, faS
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { usePathname, useSearchParams } from 'next/navigation'
 import { VALID_SORT_OPTIONS } from 'src/data/queries/searchDoiQuery'
+import Link from 'next/link'
 
 const WorksDashboard = dynamic(() => import('src/components/WorksDashboard/WorksDashboard'), { ssr: false })
 const SankeyGraph = dynamic(() => import('src/components/SankeyGraph/SankeyGraph'), { ssr: false })
@@ -218,7 +219,7 @@ function Item(props: {
   }
   params.delete('cursor')
 
-  return <Dropdown.Item href={`${pathname}/?${params.toString()}`} active={isActive} className="d-inline-flex align-items-center gap-1">
+  return <Dropdown.Item href={`${pathname}/?${params.toString()}`} active={isActive} className="d-inline-flex align-items-center gap-1" as={Link}>
     <FontAwesomeIcon className={!isActive ? "text-secondary" : ""} icon={props.icon} /> {props.children}
     {props.order && <span className={`${!isActive ? "text-secondary" : ""} ms-auto text-end ps-4`}>{props.order}</span>}
   </Dropdown.Item>

--- a/src/components/WorksListing/WorksListing.tsx
+++ b/src/components/WorksListing/WorksListing.tsx
@@ -16,7 +16,7 @@ import Pager from 'src/components/Pager/Pager'
 import type { ShowCharts } from 'src/components/WorksDashboard/WorksDashboard'
 import { multilevelToSankey } from 'src/components/SankeyGraph/sankeyUtils'
 import Dropdown from 'react-bootstrap/Dropdown'
-import { faSortAlphaAsc, faSortAlphaDesc, faSortAlphaUp, faSortAmountAsc, faSortNumericAsc, faSortNumericDesc, faSortNumericUp, faTimes, IconDefinition } from '@fortawesome/free-solid-svg-icons'
+import { faCheck, faSortAlphaAsc, faSortAlphaUp, faSortAmountAsc, faSortNumericUp, IconDefinition } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { usePathname, useSearchParams } from 'next/navigation'
 import { VALID_SORT_OPTIONS } from 'src/data/queries/searchDoiQuery'
@@ -147,13 +147,13 @@ export default function WorksListing({
 
 const A_TO_Z = 'A to Z'
 const Z_TO_A = 'Z to A'
-const NEWEST_FIRST = 'newest first'
-const OLDEST_FIRST = 'oldest first'
-const HIGH_TO_LOW = 'high to low'
-const LOW_TO_HIGH = 'low to high'
+// const NEWEST_FIRST = 'newest first'
+// const OLDEST_FIRST = 'oldest first'
+// const HIGH_TO_LOW = 'high to low'
+// const LOW_TO_HIGH = 'low to high'
 
 const SORT_OPTIONS = [
-  // { value: 'relevance', label: 'Relevance (default)', order: undefined, icon: faSortAmountAsc, appendDivider: true },
+  { value: null, label: 'Relevance', order: undefined, icon: faSortAmountAsc, appendDivider: true },
   // { value: '-published', label: 'Published', order: NEWEST_FIRST, icon: faSortNumericDesc },
   // { value: 'published', label: 'Published', order: OLDEST_FIRST, icon: faSortNumericAsc },
   // { value: 'name', label: 'DOI Name', order: A_TO_Z, icon: faSortAlphaAsc },
@@ -173,7 +173,6 @@ const SORT_OPTIONS = [
 ] as const
 
 export function SortBy() {
-  const pathname = usePathname()
   const searchParams = useSearchParams()
   const params = new URLSearchParams(Array.from(searchParams?.entries() || []));
 
@@ -185,8 +184,8 @@ export function SortBy() {
 
   return <div className="d-flex align-items-center">
     <Dropdown>
-      <Dropdown.Toggle className="border-0 m-0" variant="light">
-        <FontAwesomeIcon icon={activeSort.icon} /> {activeSort.label}
+      <Dropdown.Toggle className="border-0 m-0 bg-transparent" variant="light">
+        <span className="text-secondary">Sort by:</span> {activeSort.label} {"order" in activeSort && activeSort.order && `(${activeSort.order})`}
       </Dropdown.Toggle>
 
       <Dropdown.Menu className="remove-dropdown-margin">
@@ -205,22 +204,11 @@ export function SortBy() {
         ))}
       </Dropdown.Menu>
     </Dropdown>
-
-    {activeSort.value && <Link
-      href={`${pathname}/?${params.toString()}`}
-      id="search-clear"
-      type="button"
-      title="Clear sort"
-      aria-label="Clear sort"
-      className="text-secondary"
-    >
-      <FontAwesomeIcon icon={faTimes} />
-    </Link>}
   </div>
 }
 
 function Item(props: {
-  value: typeof VALID_SORT_OPTIONS[number],
+  value: null | typeof VALID_SORT_OPTIONS[number],
   order?: string,
   icon: IconDefinition,
   children: React.ReactNode
@@ -232,7 +220,7 @@ function Item(props: {
   const isActive = params.get('sort') === props.value
   const isSelected = isActive || (props.value === 'relevance' && !params.get('sort'))
 
-  if (isActive) {
+  if (isActive || !props.value) {
     // if param is present, delete from query
     params.delete('sort')
   } else {
@@ -241,8 +229,9 @@ function Item(props: {
   }
   params.delete('cursor')
 
-  return <Dropdown.Item href={`${pathname}/?${params.toString()}`} active={isSelected} className="d-inline-flex align-items-center gap-1" as={Link}>
-    <FontAwesomeIcon className={!isSelected ? "text-secondary" : ""} icon={props.icon} /> {props.children}
-    {props.order && <span className={`${!isSelected ? "text-secondary" : ""} ms-auto text-end ps-4`}>{props.order}</span>}
+  return <Dropdown.Item href={`${pathname}/?${params.toString()}`} className="d-inline-flex align-items-center gap-1" as={Link}>
+    <FontAwesomeIcon icon={faCheck} opacity={isSelected ? 1 : 0} />
+    {props.children}
+    {props.order && <span className="text-secondary ms-auto text-end ps-4">{props.order}</span>}
   </Dropdown.Item>
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -687,29 +687,29 @@ body {
   /* https://datacite.org/wp-content/uploads/2024/06/DataCite_Design_manual-version_2_1.pdf */
 
   /* Primary colors */
-  --datacite-primary-dark-blue:  #243B54;
+  --datacite-primary-dark-blue: #243B54;
   --datacite-primary-light-blue: #00B1E2;
   --datacite-primary-light-blue-darker: color-mix(in srgb, var(--datacite-primary-light-blue), black 40%);
 
   /* Secondary colors (use in combination with primary dark blue) */
-  --datacite-secondary-grey:     #C0CED6;
+  --datacite-secondary-grey: #C0CED6;
   --datacite-secondary-grey-dark: color-mix(in srgb, var(--datacite-secondary-grey), black 40%);
   --datacite-secondary-turquoise: #46BCAB;
   --datacite-secondary-turquoise-dark: color-mix(in srgb, var(--datacite-secondary-turquoise), black 30%);
   --datacite-secondary-light-red: #F07C73;
 
   /* Additional colors */
-  --datacite-medium-blue:        #0D60D4;
-  --datacite-dark-pink:          #BC2B66;
-  --datacite-lime:               #E2E254;
+  --datacite-medium-blue: #0D60D4;
+  --datacite-dark-pink: #BC2B66;
+  --datacite-lime: #E2E254;
 
   /* Gradient endpoints (for backgrounds, infographics) */
-  --datacite-gradient-start:     var(--datacite-primary-light-blue);
-  --datacite-gradient-end:     var(--datacite-primary-dark-blue);
+  --datacite-gradient-start: var(--datacite-primary-light-blue);
+  --datacite-gradient-end: var(--datacite-primary-dark-blue);
 
   --datacite-color-primary: var(--datacite-primary-dark-blue);
   --datacite-color-secondary: var(--datacite-secondary-turquoise-dark, #318478);
-  --datacite-link-primary: var(--datacite-primary-light-blue-darker,#0071b2);
+  --datacite-link-primary: var(--datacite-primary-light-blue-darker, #0071b2);
 }
 
 .button:hover,
@@ -735,7 +735,8 @@ h3.member-results {
   color: var(--datacite-color-primary, #243b54);
 }
 
-.nav-tabs-member>li>button:focus, .nav-tabs-member button.active {
+.nav-tabs-member>li>button:focus,
+.nav-tabs-member button.active {
   color: var(--datacite-color-secondary, #1abc9c) !important;
 }
 
@@ -753,4 +754,16 @@ span.metrics-counter {
   margin-top: .5em;
   font-weight: 700;
   line-height: 1.2em;
+}
+
+.dropdown-menu {
+  --bs-dropdown-link-active-bg: var(--datacite-color-secondary);
+}
+
+.remove-dropdown-margin.show {
+  margin-top: 0 !important;
+}
+
+.dropdown-divider {
+  width: 100% !important;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -757,7 +757,8 @@ span.metrics-counter {
 }
 
 .dropdown-menu {
-  --bs-dropdown-link-active-bg: var(--datacite-color-secondary);
+  --bs-dropdown-link-active-bg: #34495E;
+  overflow: hidden;
 }
 
 .remove-dropdown-margin.show {

--- a/src/styles.css
+++ b/src/styles.css
@@ -757,7 +757,7 @@ span.metrics-counter {
 }
 
 .dropdown-menu {
-  --bs-dropdown-link-active-bg: #34495E;
+  --bs-dropdown-link-active-bg: initial;
   overflow: hidden;
 }
 
@@ -767,4 +767,12 @@ span.metrics-counter {
 
 .dropdown-divider {
   width: 100% !important;
+}
+
+.bg-transparent,
+.bg-transparent:hover,
+.bg-transparent:focus,
+.bg-transparent:active {
+  color: initial !important;
+  background-color: transparent !important;
 }


### PR DESCRIPTION
## Purpose
Adds a dropdown to the DOI list headings to select how to sort DOI search results.

closes: https://github.com/datacite/product-backlog/issues/443

## Approach
<!--- _How does this change address the problem?_ -->

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a sortable “Related Works” results header with an adjacent dropdown control across DOI, ORCID, Repository, and ROR pages.
  * Enabled sorting for works search/listing results when matches are available, including a “clear sort” option that resets back to the default.
  * Sorting state is synchronized with the page’s URL query parameters to keep results consistent.
* **Style**
  * Updated the results summary layout to use a bordered row with aligned heading and dropdown.
  * Refined dropdown styling/spacing via global CSS overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->