### PR TITLE
docs: add AGENTS.md with Cursor Cloud dev environment notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ in `package.json`; setup lives in `README.md`. Notes below are the non-obvious b
 
 The update script already runs `corepack enable` + `yarn install`, so Yarn 4 and the
 Node dependencies are ready when a session starts. Just run `yarn dev-all` (or `yarn dev`
-for frontend only). In dev, Next proxies `/api/*` → `http://127.0.0.1:5328` (see
+for frontend only). In dev, Next proxies `/api/*` → `http://127.0.0.1:5328/api/*` (see
 `next.config.js`), which is how the frontend reaches the Flask API.
 
 ### Python API (uv)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,50 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+Akita is the **DataCite Commons** frontend: a Next.js 15 / React 19 app (port `3000`)
+plus an optional Flask Python API (port `5328`) used only for the related-works graph.
+There is no local database — all data comes from remote APIs (DataCite stage, ORCID
+sandbox, ROR), so the environment needs outbound network access. Standard scripts live
+in `package.json`; setup lives in `README.md`. Notes below are the non-obvious bits.
+
+### Services
+
+| Service | Must run? | Port | Start command |
+| --- | --- | --- | --- |
+| Next.js frontend | Yes | 3000 | `yarn dev` |
+| Flask API (related-works graph) | Optional | 5328 | `yarn api` |
+| Both together | — | 3000 + 5328 | `yarn dev-all` |
+
+The update script already runs `corepack enable` + `yarn install`, so Yarn 4 and the
+Node dependencies are ready when a session starts. Just run `yarn dev-all` (or `yarn dev`
+for frontend only). In dev, Next proxies `/api/*` → `http://127.0.0.1:5328` (see
+`next.config.js`), which is how the frontend reaches the Flask API.
+
+### Python API (uv)
+
+- The API is managed by **uv** (installed system-wide at `/usr/local/bin/uv`; the update
+  script does not install it). `yarn api` / `yarn dev-all` run `uv sync --project api`
+  themselves on first launch, so you normally do not need to sync manually.
+- The Flask app only serves `/api/doi/related-graph/<doi>` and `/api/doi/related-list/<doi>`;
+  hitting `/` returns 404, which is expected — that does not mean the API is down.
+
+### Linting caveat (important)
+
+- `yarn lint` currently **fails**: `.eslintrc.js` references `eslint-plugin-react`, which is
+  not a declared dependency, and no CI workflow runs lint. The same warning appears during
+  `yarn build` but is non-fatal (the build still succeeds).
+- Use `yarn type-check` (tsc) for type validation and `yarn prettier-format` for formatting.
+
+### Cypress e2e tests
+
+- Cypress runs against a **production build**, not the dev server. Use two terminals:
+  1. `yarn build`, then `CYPRESS_NODE_ENV=test yarn start` (leave running on `:3000`).
+  2. `yarn cy:run` once `:3000` is up.
+- `CYPRESS_NODE_ENV=test` must be set on the **Next.js server**, not only on the Cypress
+  command. It enables strict API mocking (unmocked browser calls return HTTP 599); without
+  it, tests fail. The Flask API does not need to run — the related-graph is mocked.
+- The Cypress binary is not installed by `yarn install` (`enableScripts: false` in
+  `.yarnrc.yml`). It is cached under `~/.cache/Cypress`; if missing, run
+  `yarn exec cypress install`.
+- Free port 3000 before starting the dev server again after a Cypress run.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ for frontend only). In dev, Next proxies `/api/*` → `http://127.0.0.1:5328` (s
 - `yarn lint` currently **fails**: `.eslintrc.js` references `eslint-plugin-react`, which is
   not a declared dependency, and no CI workflow runs lint. The same warning appears during
   `yarn build` but is non-fatal (the build still succeeds).
-- Use `yarn type-check` (tsc) for type validation and `yarn prettier-format` for formatting.
+- Use `yarn type-check` (tsc) for type validation and `yarn prettier --config .prettierrc.json --write .` for formatting.
 
 ### Cypress e2e tests
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and documents the development environment for Akita (DataCite Commons frontend) so future Cursor Cloud agents can start and test the app reliably. The only code change is a new `AGENTS.md`; no application code was modified.

## What was verified

- Frontend (`yarn dev`, Next.js 15 + Turbopack) and Flask API (`yarn api`, `uv`) both run via `yarn dev-all` (ports 3000 / 5328).
- Type-check passes (`yarn type-check`).
- Full Cypress e2e suite passes: **45 passing / 0 failing across 18 specs** via `CYPRESS_NODE_ENV=test yarn start` + `yarn cy:run`.
- Hello-world task: searched "climate change" (10,432 live results from the DataCite backend) and opened a work detail page including the related-works connections graph.

## AGENTS.md notes (non-obvious)

- The Flask API is managed by `uv` (installed system-wide; not in the update script). `yarn api` runs `uv sync` itself.
- `yarn lint` fails because `.eslintrc.js` references `eslint-plugin-react`, which is not a declared dependency and is not run in CI — use `yarn type-check` instead. (pre-existing, unrelated to this change)
- Cypress runs against a production build with `CYPRESS_NODE_ENV=test` on the Next server (strict API mocks); the Cypress binary is not installed by `yarn install` (`enableScripts: false`).

## Update script

```
corepack enable
yarn install
```

## Demo

[akita_search_climate_change_e2e.mp4](https://cursor.com/agents/bc-3c1ba430-cd27-48d7-bea5-a18730bc3246/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fakita_search_climate_change_e2e.mp4)

[DataCite Commons home page](https://cursor.com/agents/bc-3c1ba430-cd27-48d7-bea5-a18730bc3246/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fakita_home_page.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3c1ba430-cd27-48d7-bea5-a18730bc3246"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3c1ba430-cd27-48d7-bea5-a18730bc3246"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added project guidance covering setup, service startup, API routing, linting, type checking, formatting, and Cypress testing procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->