### PR TITLE
Fix affiliation behavior to return object only when true

### DIFF
--- a/cypress/fixtureManifest.cjs
+++ b/cypress/fixtureManifest.cjs
@@ -58,7 +58,7 @@ const manifest = [
       `${dataciteBase(env)}/dois?${new URLSearchParams({
         query: 'climate',
         include: 'client',
-        affiliation: 'false',
+        affiliation: 'true',
         publisher: 'false',
         'disable-facets': 'true',
         include_other_registration_agencies: 'true',
@@ -74,7 +74,7 @@ const manifest = [
       `${dataciteBase(env)}/dois?${new URLSearchParams({
         query: 'climate',
         include: 'client',
-        affiliation: 'false',
+        affiliation: 'true',
         publisher: 'false',
         'disable-facets': 'true',
         include_other_registration_agencies: 'true',
@@ -90,7 +90,7 @@ const manifest = [
       `${dataciteBase(env)}/dois?${new URLSearchParams({
         query: 'climate',
         facets: DEFAULT_FACETS,
-        affiliation: 'false',
+        affiliation: 'true',
         publisher: 'false',
         'disable-facets': 'false',
         include_other_registration_agencies: 'true',
@@ -105,7 +105,7 @@ const manifest = [
       `${dataciteBase(env)}/dois?${new URLSearchParams({
         query: 'uid:"10.7272/q6g15xs4"',
         include: 'client',
-        affiliation: 'false',
+        affiliation: 'true',
         publisher: 'true',
         'disable-facets': 'true',
         include_other_registration_agencies: 'true',
@@ -120,7 +120,7 @@ const manifest = [
       `${dataciteBase(env)}/dois?${new URLSearchParams({
         query: 'uid:"10.17863/cam.10544"',
         include: 'client',
-        affiliation: 'false',
+        affiliation: 'true',
         publisher: 'true',
         'disable-facets': 'true',
         include_other_registration_agencies: 'true',
@@ -136,7 +136,7 @@ const manifest = [
         query:
           'creators_and_contributors.nameIdentifiers.nameIdentifier:(0000-0001-6528-2027 OR "https://orcid.org/0000-0001-6528-2027")',
         include: 'client',
-        affiliation: 'false',
+        affiliation: 'true',
         publisher: 'false',
         'disable-facets': 'true',
         include_other_registration_agencies: 'true',
@@ -153,7 +153,7 @@ const manifest = [
         query:
           'creators_and_contributors.nameIdentifiers.nameIdentifier:(0000-0001-6528-2027 OR "https://orcid.org/0000-0001-6528-2027")',
         facets: METRICS_FACETS,
-        affiliation: 'false',
+        affiliation: 'true',
         publisher: 'false',
         'disable-facets': 'false',
         include_other_registration_agencies: 'true',
@@ -169,7 +169,7 @@ const manifest = [
         query:
           'creators_and_contributors.nameIdentifiers.nameIdentifier:(0000-0001-6528-2027 OR "https://orcid.org/0000-0001-6528-2027")',
         facets: DEFAULT_FACETS,
-        affiliation: 'false',
+        affiliation: 'true',
         publisher: 'false',
         'disable-facets': 'false',
         include_other_registration_agencies: 'true',
@@ -185,7 +185,7 @@ const manifest = [
         query:
           'creators_and_contributors.nameIdentifiers.nameIdentifier:(0000-0001-6528-2027 OR "https://orcid.org/0000-0001-6528-2027") AND (datacite)',
         facets: DEFAULT_FACETS,
-        affiliation: 'false',
+        affiliation: 'true',
         publisher: 'false',
         'disable-facets': 'false',
         include_other_registration_agencies: 'true',
@@ -201,7 +201,7 @@ const manifest = [
         query:
           '(organization_id:"ror.org/013meh722" OR provider.ror_id:"https://ror.org/013meh722" OR affiliation_id:"ror.org/013meh722" OR related_dmp_organization_id:"ror.org/013meh722" OR funder_rors:"https://ror.org/013meh722" OR funder_parent_rors:"https://ror.org/013meh722") AND (cambridge)',
         include: 'client',
-        affiliation: 'false',
+        affiliation: 'true',
         publisher: 'false',
         'disable-facets': 'true',
         include_other_registration_agencies: 'true',
@@ -218,7 +218,7 @@ const manifest = [
         query:
           '(organization_id:"ror.org/013meh722" OR provider.ror_id:"https://ror.org/013meh722" OR affiliation_id:"ror.org/013meh722" OR related_dmp_organization_id:"ror.org/013meh722" OR funder_rors:"https://ror.org/013meh722" OR funder_parent_rors:"https://ror.org/013meh722") AND (cambridge)',
         facets: DEFAULT_FACETS,
-        affiliation: 'false',
+        affiliation: 'true',
         publisher: 'false',
         'disable-facets': 'false',
         include_other_registration_agencies: 'true',

--- a/src/data/queries/doiQuery.ts
+++ b/src/data/queries/doiQuery.ts
@@ -7,7 +7,7 @@ function buildDoiSearchParams(id: string): URLSearchParams {
   return new URLSearchParams({
     query: `uid:"${id}"`,
     include: 'client',
-    affiliation: 'false',
+    affiliation: 'true',
     publisher: 'true',
     'disable-facets': 'true',
     include_other_registration_agencies: 'true',

--- a/src/data/queries/searchDoiFacetsQuery.ts
+++ b/src/data/queries/searchDoiFacetsQuery.ts
@@ -8,7 +8,7 @@ function buildDoiSearchParams(variables: QueryVar, facets: string[]): URLSearchP
   const searchParams = new URLSearchParams({
     query: buildQuery(variables),
     facets: facets.join(','),
-    affiliation: 'false',
+    affiliation: 'true',
     publisher: 'false',
     'disable-facets': 'false',
     include_other_registration_agencies: 'true',

--- a/src/data/queries/searchDoiQuery.ts
+++ b/src/data/queries/searchDoiQuery.ts
@@ -27,7 +27,7 @@ const VALID_CONNECTION_TYPES = [
   'otherRelated',
 ] as const;
 
-function buildRelatedDoiQuery(relatedDoi: string | undefined, uidList: string[] | undefined, connectionType="allRelated" ): string {
+function buildRelatedDoiQuery(relatedDoi: string | undefined, uidList: string[] | undefined, connectionType = "allRelated"): string {
   if (!relatedDoi) return ''
   // if the connection type is not in the map, return an empty string
   if (!VALID_CONNECTION_TYPES.includes(connectionType as typeof VALID_CONNECTION_TYPES[number])) return ''
@@ -181,7 +181,7 @@ function buildDoiSearchParams(variables: QueryVar, count?: number): URLSearchPar
   const searchParams = new URLSearchParams({
     query: buildQuery(variables),
     include: 'client',
-    affiliation: 'false',
+    affiliation: 'true',
     publisher: 'false',
     'disable-facets': 'true',
     include_other_registration_agencies: 'true'


### PR DESCRIPTION
## Purpose
set `affiliation=true`, as `affiliation=false` no longer returns the object per https://github.com/datacite/datacite/issues/2483

closes: _Add github issue that originated this PR_

## Approach
<!--- _How does this change address the problem?_ -->

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DOI search results by enabling affiliation data in DataCite searches.
  * Enabled affiliation-related facets in DOI search results for more relevant filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->